### PR TITLE
Modal global styles and small adjustments

### DIFF
--- a/frontend/src/AddingAuthorModal.jsx
+++ b/frontend/src/AddingAuthorModal.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import useCheckUser from './useCheckUser';
 
-function NewAuthorPage() {
+function AddingAuthorModal() {
   const [firstName, setFirstName] = useState(null);
   const [lastName, setLastName] = useState(null);
   const [country, setCountry] = useState(null);
@@ -65,4 +65,4 @@ function NewAuthorPage() {
   )
 }
 
-export default NewAuthorPage;
+export default AddingAuthorModal;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,7 +4,7 @@ import LoginPage from './Login.jsx';
 import './Global.scss';
 import AuthorPage from './AuthorPage.jsx';
 import AuthorsList from './AuthorsList.jsx';
-import NewAuthorPage from './NewAuthorPage.jsx';
+import NewAuthorPage from './AddingAuthorModal.jsx';
 import EditAuthorPage from './EditAuthorModal.jsx';
 import DeleteAuthorPage from './DeleteAuthorModal.jsx';
 import ConfirmationCodePage from './ConfirmationCodePage.jsx';

--- a/frontend/src/AuthorsList.jsx
+++ b/frontend/src/AuthorsList.jsx
@@ -6,6 +6,7 @@ import UserContext from "./UserContext";
 import DeleteAuthorModal from './DeleteAuthorModal';
 import EditAuthorModal from './EditAuthorModal';
 import useCheckUser from './useCheckUser';
+import AddingAuthorModal from './AddingAuthorModal';
 
 function AuthorsList() {
   useCheckUser();
@@ -14,9 +15,10 @@ function AuthorsList() {
   const [deleteModal, setDeleteModal] = useState(null);
   const [isEditModalOpen, setOpenEditModal] = useState(false);
   const [editModal, setEditModal] = useState(null);
+  const [isAddingModalOpen, setOpenAddingModal] = useState(false);
+  const [addingModal, setAddingModal] = useState(null);
   const { user } = useContext(UserContext);
   const [isLoading, setLoading] = useState(true);
-  console.log(data);
 
   const columns = useMemo(() => [
     {
@@ -55,7 +57,10 @@ function AuthorsList() {
   ], []);
   const table = useMaterialReactTable({
     columns,
-    data
+    data,
+    renderTopToolbarCustomActions: () => (
+      <button onClick={openAddingModal}>Añadir nuevo autor</button>
+    )
   });
 
   function openDeleteModal(row) {
@@ -76,6 +81,16 @@ function AuthorsList() {
   function closeEditModal() {
     setEditModal(null);
     setOpenEditModal(false);
+  }
+
+  function openAddingModal() {
+    setAddingModal(<AddingAuthorModal closeAddingModal={closeAddingModal} />);
+    setOpenAddingModal(true);
+  }
+
+  function closeAddingModal() {
+    setAddingModal(null);
+    setOpenAddingModal(false);
   }
 
   // Hook to set to Loading and not show the page before authenticating user
@@ -115,6 +130,7 @@ function AuthorsList() {
       <>
         {isDeleteModalOpen && deleteModal}
         {isEditModalOpen && editModal}
+        {isAddingModalOpen && addingModal}
         <div className="authors-list">
           <div className="authors-links">
             <Link to='/admin/new-author' className="blue-button">Añadir nuevo autor</Link>

--- a/frontend/src/DeleteAuthorModal.jsx
+++ b/frontend/src/DeleteAuthorModal.jsx
@@ -24,16 +24,16 @@ function DeleteAuthorModal({ row, closeDeleteModal }) {
   }
 
   return (
-    <div className="delmod-overlay" onClick={closeDeleteModal}>
-      <div className="delmod-proper">
+    <div className="modal-overlay" onClick={closeDeleteModal}>
+      <div className="modal-proper">
         <div className="delmod-confirm">
           <p>{`¿Está seguro que quiere eliminar el autor
           ${row.first_name} ${row.last_name}?`}</p>
         </div>
-        <div className="delmod-actions">
-          <button className='blue-button delmod-button'
+        <div className="modal-actions">
+          <button className='blue-button modal-button'
             onClick={closeDeleteModal}>Cancelar</button>
-          <button className='blue-button delmod-button'
+          <button className='blue-button modal-button'
             onClick={deleteAuthor}>Confirmar</button>
         </div>
       </div>

--- a/frontend/src/DeleteAuthorModal.scss
+++ b/frontend/src/DeleteAuthorModal.scss
@@ -1,24 +1,3 @@
-.delmod-overlay {
-  z-index: 1000;
-  width: 100vw;
-  height: 100vh;
-  background-color: rgba(0, 0, 0, 0.5);
-  position: fixed;
-  top: 0;
-  left: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-.delmod-proper {
-  z-index: 2000;
-  background-color: #E2E2E2;
-  width: 30%;
-  border-radius: 15px;
-  padding: 1rem;
-}
-
 .delmod-confirm {
   display: flex;
   justify-content: center;
@@ -29,15 +8,4 @@
 
 .delmod-confirm p {
   margin: 0
-}
-
-.delmod-actions {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-.delmod-button {
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
 }

--- a/frontend/src/EditAuthorModal.jsx
+++ b/frontend/src/EditAuthorModal.jsx
@@ -41,8 +41,8 @@ function EditAuthorModal({ row, closeEditModal }) {
   }
 
   return (
-    <div className="delmod-overlay">
-      <div className="delmod-proper">
+    <div className="modal-overlay">
+      <div className="modal-proper">
         <form>
           <input type="text" placeholder={`${row.first_name}`}
             onChange={(e)=>setFirstName(e.target.value)}></input>
@@ -57,10 +57,10 @@ function EditAuthorModal({ row, closeEditModal }) {
           <input type="text" placeholder={`${row.category}`}
             onChange={(e)=>setCategory(e.target.value)}></input>
         </form>
-        <div className="delmod-actions">
-          <button className='blue-button delmod-button'
+        <div className="modal-actions">
+          <button className='blue-button modal-button'
               onClick={closeEditModal}>Cancelar</button>
-          <button className='blue-button delmod-button'
+          <button className='blue-button modal-button'
             onClick={editAuthor}>Confirmar</button>
         </div>
       </div>

--- a/frontend/src/Global.scss
+++ b/frontend/src/Global.scss
@@ -56,3 +56,37 @@ a {
 .grey-button:hover {
   cursor: pointer;
 }
+
+// Modals
+
+.modal-overlay {
+  z-index: 1000;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5);
+  position: fixed;
+  top: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.modal-proper {
+  z-index: 2000;
+  background-color: #E2E2E2;
+  width: 30%;
+  border-radius: 15px;
+  padding: 1rem;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.modal-button {
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+}

--- a/frontend/src/Navbar.jsx
+++ b/frontend/src/Navbar.jsx
@@ -50,7 +50,7 @@ function Navbar() {
         <img src={logo} alt="was-editorial-logo" className="navbar-srcLogo"></img>
       </div>
       <div className='navbar-logout'>
-        {(user !== null) &&
+        {(user !== '') &&
           <p className="grey-button" onClick={logout}>Logout</p>}
       </div>
     </div>


### PR DESCRIPTION
- Transformed delmod styles (originally for the DeleteAuthorModal) into global modal styles.
- Applied them on EditAuthorModal.
- Added a quick change to ensure the Navbar on the Login page would behave as intended when no user exists (not null, user == "").
- Added the 'anadir nuevo autor' within the table header, in preparation for transforming NewAuthorPage into a modal and achieve functional parity with other crud actions (edit or delete author). 