### PR TITLE
Sales now reflect on inventories

### DIFF
--- a/backend/prisma/migrations/20250305231853_added_current_column_in_inventory/migration.sql
+++ b/backend/prisma/migrations/20250305231853_added_current_column_in_inventory/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `current` to the `Inventory` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Inventory" ADD COLUMN     "current" INTEGER NOT NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -85,6 +85,7 @@ model Inventory {
   bookstoreId Int
   country     String
   initial     Int
+  current     Int
   sales       Sale[]
   isDeleted   Boolean   @default(false)
   createdAt   DateTime  @default(now())

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -142,6 +142,7 @@ async function main() {
       bookstoreId: 1,
       country: "México",
       initial: 1000,
+      current: 1000
     }
   })
 
@@ -151,6 +152,7 @@ async function main() {
       bookstoreId: 1,
       country: "México",
       initial: 1000,
+      current: 1000
     }
   })
 

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -564,6 +564,7 @@ router.get('/inventories', async (req, res) => {
         },
         country: true,
         initial: true,
+        current: true
       },
       orderBy: {
         book: {
@@ -594,7 +595,8 @@ router.post('/inventory', async (req, res) => {
         bookId: book,
         bookstoreId: bookstore,
         country: country,
-        initial: inicial
+        initial: inicial,
+        current: inicial
       }
     });
     res.status(201).json(createdInventory);

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -745,8 +745,13 @@ router.post('/sale', async (req, res) => {
         country: country
       }}});
 
+    if (!selectedInventory) {
+      res.status(400).json({ message: "No existe un inventario con esta combinación de titulo, librería y país"});
+      return;
+    }
+
     if (selectedInventory.current < quantity) {
-      res.status(400).json({ error: "El inventario tiene menos libros que la cantidad entrada."})
+      res.status(400).json({ message: "El inventario tiene menos libros que la cantidad entrada."});
       return;
     }
 

--- a/frontend/src/InventoriesList.jsx
+++ b/frontend/src/InventoriesList.jsx
@@ -47,7 +47,6 @@ function InventoriesList() {
     },
     {
       header: "Cantidad",
-      // accessorKey: "initial"
       Cell: ({row}) => (
         <p>{row.original.current}/{row.original.initial}</p>
       )

--- a/frontend/src/InventoriesList.jsx
+++ b/frontend/src/InventoriesList.jsx
@@ -19,6 +19,8 @@ function InventoriesList() {
   const [alertMessage, setAlertMessage] = useState("");
   const [alertType, setAlertType] = useState("");
 
+  console.log(data);
+
   const columns = useMemo(() => [
     {
       header: "Acciones",
@@ -44,8 +46,11 @@ function InventoriesList() {
       accessorKey: "country"
     },
     {
-      header: "Cantidad inicial",
-      accessorKey: "initial"
+      header: "Cantidad",
+      // accessorKey: "initial"
+      Cell: ({row}) => (
+        <p>{row.original.current}/{row.original.initial}</p>
+      )
     }
   ], []);
   const table = useMaterialReactTable({


### PR DESCRIPTION
- Modified the DB schema so that inventories also hold the current number of books. 
- Modified the seed so that dummy inventories created also have a current number equal to the initial number of books. 
- Modified inventories admin routes to be able to fetch current. 
- Modified the display in the table so that current and initial quantities would show up.
- Modified the create sale route so that it now checks whether there's a sufficient amount of books in the inventory before creating the sale. 
- This updates the inventory current numbers if the check is passed successfully.
- Fixed an issue where the server errors would not be surfaced in AddingSalesModal. 
- Added two different server errors for uniqueness combination and quantity too high.