### PR TITLE
Cascading soft delete functions

### DIFF
--- a/frontend/src/TableActions.jsx
+++ b/frontend/src/TableActions.jsx
@@ -12,7 +12,6 @@ function TableActions({openModal, row}) {
   const [x, setX] = useState(null);
   const [y, setY] = useState(null);
   const [tooltipMessage, setTooltipMessage] = useState('');
-  console.log(row);
 
   function displayingActions() {
     if (gearRef.current.classList.contains("displaying")) {


### PR DESCRIPTION
- Refactored how the books of a deleted author where also self deleted: transformed it into its own function that returns the ids of the books that it soft deleted so that the cascade could keep on. 
- Created a softDeleteInventoriesOnCascade function that accepts either books Ids or bookstores Ids to soft delete linked inventories as a continuation of the cascade.
- Added another function for deleting sales on cascade.
- Used these functions on every model to soft delete things on cascade properly.