### PR TITLE
Login soft delete checks

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -385,7 +385,6 @@
       "version": "16.4.7",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
       "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "@prisma/client": "^6.3.1",
     "bcrypt": "^5.1.1",
     "cors": "^2.8.5",
+    "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "express-session": "^1.18.1",
     "node": "^18.20.6",

--- a/backend/routes/superAdminRoutes.js
+++ b/backend/routes/superAdminRoutes.js
@@ -123,7 +123,7 @@ router.delete('/admin', async (req, res) => {
     await prisma.user.update({where:
       {id: user_id},
       data: {
-        isDeleted: true
+        isDeleted: true,
       }
     });
     res.status(200).json({message: "El admin ha sido eliminado (recuperable) con exito."})

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -9,7 +9,11 @@ const router = express.Router();
 router.post('/login', async (req, res) => {
   try {
     const { email, password } = req.body;
-    const user = await prisma.user.findUnique({where: {email: email}});
+    const user = await prisma.user.findUnique({
+      where: {
+        email: email,
+        isDeleted: false
+      }});
     if (user === null) {
       return res.status(401).send("No tenemos una cuenta registrada con este correo.");
     }

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -43,7 +43,10 @@ router.post('/login', async (req, res) => {
 router.get('/user', async (req, res) => {
   try {
     const email = req.query.email;
-    const user = await prisma.user.findUnique({where: {email: email}});
+    const user = await prisma.user.findUnique({where: {
+      email: email,
+      isDeleted: false
+    }});
 
     if (user === null) {
       res.status(204).json("No user with this email were found");

--- a/backend/utils.js
+++ b/backend/utils.js
@@ -29,7 +29,10 @@ export async function setResetPasswordCode(user_id, code) {
 
 export async function matchConfirmationCode(confirmation_code, user_id) {
   try {
-    const user = await prisma.user.findUnique({where: {id: user_id}});
+    const user = await prisma.user.findUnique({where:{
+      id: user_id,
+      isDeleted: false
+      }});
     if (user === false) {
       throw new Error('No user found.')
     };


### PR DESCRIPTION
- Made sure login checked the user wasn't soft deleted too, so that you wouldn't unwillingly keep access for deleted users (authors and admins).
- Changed userRoutes to get user and match confirmation codes (in utils) to ensure the user fetched is not marked as deleted.