### PR TITLE
Modified Payments fetch to display 12 last months of payments.

### DIFF
--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -471,11 +471,13 @@ async function main() {
     // Create a new payment for each month
     for (const month of salesByMonthsList) {
       console.log("MONTH", month);
+
       const newPayment = await prisma.payment.create({
         data: {
           userId: author.id,
           amount: month[1],
           forMonth: month[0],
+          createdAt: new Date(month[0]+'-25')
         }
       })
     }

--- a/frontend/src/AuthorComissions.jsx
+++ b/frontend/src/AuthorComissions.jsx
@@ -12,6 +12,7 @@ function AuthorCommissions() {
   const [dataByMonths, setDataByMonths] = useState(null);
   const [activeMonth, setActiveMonth] = useState(0);
   const [payments, setPayments] = useState(null);
+  console.log(payments);
 
   async function fetchAuthorBookSales() {
     try {

--- a/frontend/src/CommissionMonthSelectorRow.jsx
+++ b/frontend/src/CommissionMonthSelectorRow.jsx
@@ -22,6 +22,8 @@ function CommissionMonthSelectorRow({index, month, active, setActiveMonth}) {
     return months[date.substring(5,7)] + " " + date.substring(0,4);
   }
 
+  console.log(index);
+  
   return(
     <div
       className={active ? "cms-row-active" : "cms-row"}


### PR DESCRIPTION
- Modified the seed data so that Payments would be created each month and not everything at once at the origin (LTM). This allows for the fetching of the last 12 payments through timestamp. 
- Modified the payments backend route so that it would create phantom data (zeros) if there was no payment for this month so that this CommissionMonthSelector would create a row even if no payment had been made that month.