### PR TITLE
Cor/more cleanup

### DIFF
--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -721,65 +721,65 @@ router.get('/inventories', async (req, res) => {
   }
 });
 
-router.post('/inventory', async (req, res) => {
-  try {
-    const {
-      book,
-      bookstore,
-      country,
-      inicial
-    } = req.body;
-    const existing = await prisma.inventory.findUnique({
-      where: {
-        bookId_bookstoreId_country: {
-          bookId: book,
-          bookstoreId: bookstore,
-          country: country
-        }
-      }
-    });
+// router.post('/inventory', async (req, res) => {
+//   try {
+//     const {
+//       book,
+//       bookstore,
+//       country,
+//       inicial
+//     } = req.body;
+//     const existing = await prisma.inventory.findUnique({
+//       where: {
+//         bookId_bookstoreId_country: {
+//           bookId: book,
+//           bookstoreId: bookstore,
+//           country: country
+//         }
+//       }
+//     });
 
-    if (existing) {
-      if (existing.isDeleted === false) {
-        res.status(500).json({message: "Este inventario ya existe"})
-        return;
-      }
+//     if (existing) {
+//       if (existing.isDeleted === false) {
+//         res.status(500).json({message: "Este inventario ya existe"})
+//         return;
+//       }
 
-      const exhumedInventory = await prisma.inventory.update({
-        where: {id: existing.id},
-        data: {
-          bookId: book,
-          bookstoreId: bookstore,
-          country: country,
-          initial: inicial,
-          current: inicial,
-          isDeleted: false
-        }
-      });
-      res.status(201).json(exhumedInventory);
-      return;
-    }
+//       const exhumedInventory = await prisma.inventory.update({
+//         where: {id: existing.id},
+//         data: {
+//           bookId: book,
+//           bookstoreId: bookstore,
+//           country: country,
+//           initial: inicial,
+//           current: inicial,
+//           isDeleted: false
+//         }
+//       });
+//       res.status(201).json(exhumedInventory);
+//       return;
+//     }
 
-    const createdInventory = await prisma.inventory.create({
-      data: {
-        bookId: book,
-        bookstoreId: bookstore,
-        country: country,
-        initial: inicial,
-        current: inicial
-      }
-    });
-    res.status(201).json(createdInventory);
-  } catch (error) {
-    console.error(error);
-    if (String(error).includes(("Unique constraint failed on the fields: (`bookId`,`bookstoreId`,`country`)"))) {
-      res.status(500).json({message: "Este inventario ya existe"})
-      return;
-    }
+//     const createdInventory = await prisma.inventory.create({
+//       data: {
+//         bookId: book,
+//         bookstoreId: bookstore,
+//         country: country,
+//         initial: inicial,
+//         current: inicial
+//       }
+//     });
+//     res.status(201).json(createdInventory);
+//   } catch (error) {
+//     console.error(error);
+//     if (String(error).includes(("Unique constraint failed on the fields: (`bookId`,`bookstoreId`,`country`)"))) {
+//       res.status(500).json({message: "Este inventario ya existe"})
+//       return;
+//     }
 
-    res.status(500).json({ error: error });
-  }
-})
+//     res.status(500).json({ error: error });
+//   }
+// })
 
 router.patch('/inventory', async (req, res) => {
   try {

--- a/frontend/src/AddingTransferModal.jsx
+++ b/frontend/src/AddingTransferModal.jsx
@@ -180,9 +180,26 @@ function AddingTransferModal({clickedRow, closeModal, pageIndex, globalFilter}) 
     sendToServer();
   }
 
+  console.log(clickedRow);
+
+  useEffect(() => {
+    console.log("bookstoresToTransfer", bookstoresToTransfer);
+  }, [bookstoresToTransfer]);
+
   function checkInputs() {
     // Prepare an error list that will be displayed if any
     let errorsList = []
+
+    // Check if we're not making a transfer to the same inventory first
+    for (const transfer of bookstoresToTransfer) {
+      if (parseInt(transfer.bookstoreId) === clickedRow.bookstoreId
+        && transfer.country === clickedRow.country) {
+          errorsList.push(["No se puede transferir al mismo inventario"]);
+          setErrors(errorsList);
+          console.log("blocked");
+          return errorsList;
+      }
+    }
 
     // Set expectations for each field being tested
     const expectationsBookstore = {

--- a/frontend/src/BookInventory.jsx
+++ b/frontend/src/BookInventory.jsx
@@ -181,11 +181,11 @@ function BookInventory({
     enablePagination: false,
     enableFullScreenToggle: false,
     enableRowVirtualization: true,
-    renderTopToolbarCustomActions: () => (
-      <div className="table-add-button">
-        <button onClick={() => openModal("adding", {book: selectedBook})} className="blue-button table-button">Añadir nuevo inventario</button>
-      </div>
-    ),
+    // renderTopToolbarCustomActions: () => (
+    //   <div className="table-add-button">
+    //     <button onClick={() => openModal("adding", {book: selectedBook})} className="blue-button table-button">Añadir nuevo inventario</button>
+    //   </div>
+    // ),
     initialState: {
       density: 'compact',
     },

--- a/frontend/src/BookInventory.jsx
+++ b/frontend/src/BookInventory.jsx
@@ -44,6 +44,13 @@ function BookInventory({
     }
   }, [inventoryTotalRef])
 
+  // ensures the modalType is reset to the correct one after you add a transfer
+  useEffect(() => {
+    if (!isModalOpen) {
+      setModalType("inventory");
+    }
+  }, [modalType, isModalOpen])
+
   const columns = useMemo(() => [
     {
       header: "Acciones",
@@ -266,17 +273,15 @@ function BookInventory({
     setImpressions(sortedRelevantInventories[0].book.impressions);
   }
 
-  console.log(data)
-
   useEffect(() => {
     requestAnimationFrame(() => {
       bookInventoryRef.current.classList.add("bookstore-inventory-extended");
     });
   }, [selectedBook])
 
-  function openModal(type, clickedRow) {
+  function openModal(action, clickedRow) {
     setClickedRow(clickedRow);
-    switch (type) {
+    switch (action) {
       case 'adding':
         setModalAction("adding");
         break;

--- a/frontend/src/BookstoreInventory.jsx
+++ b/frontend/src/BookstoreInventory.jsx
@@ -245,6 +245,13 @@ function BookstoreInventory({
     selectRelevantInventories();
   }, [inventories])
 
+  // ensures the modalType is reset to the correct one after you add a transfer
+  useEffect(() => {
+    if (!isModalOpen) {
+      setModalType("inventory");
+    }
+  }, [modalType, isModalOpen])
+
   function selectRelevantInventories() {
     const relevantInventories = [];
     let currentTotal = 0;

--- a/frontend/src/BookstoreInventory.jsx
+++ b/frontend/src/BookstoreInventory.jsx
@@ -183,11 +183,11 @@ function BookstoreInventory({
     enablePagination: false,
     enableFullScreenToggle: false,
     enableRowVirtualization: true,
-    renderTopToolbarCustomActions: () => (
-      <div className="table-add-button">
-        <button onClick={() => openModal("adding", {bookstore: selectedBookstore})} className="blue-button table-button">Añadir nuevo inventario</button>
-      </div>
-    ),
+    // renderTopToolbarCustomActions: () => (
+    //   <div className="table-add-button">
+    //     <button onClick={() => openModal("adding", {bookstore: selectedBookstore})} className="blue-button table-button">Añadir nuevo inventario</button>
+    //   </div>
+    // ),
     initialState: {
       density: 'compact',
     },

--- a/frontend/src/EditInventoryModal.jsx
+++ b/frontend/src/EditInventoryModal.jsx
@@ -166,12 +166,12 @@ function EditInventoryModal({ clickedRow, closeModal, pageIndex, globalFilter}) 
 
   function checkInputs() {
     let errorsList = []
-    const expectationsBook = {
-      type: "string",
-      presence: "not empty",
-      length: 100,
-      value: bookTitlesList
-    };
+    // const expectationsBook = {
+    //   type: "string",
+    //   presence: "not empty",
+    //   length: 100,
+    //   value: bookTitlesList
+    // };
     const expectationsBookstore = {
       type: "string",
       presence: "not empty",
@@ -190,11 +190,12 @@ function EditInventoryModal({ clickedRow, closeModal, pageIndex, globalFilter}) 
       range: "positive"
     }
 
-    const errorsBook = checkForErrors("Libro", book, expectationsBook, bookRef);
+    // const errorsBook = checkForErrors("Libro", book, expectationsBook, bookRef);
     const errorsBookstore = checkForErrors("Libreria", bookstore, expectationsBookstore, bookstoreRef);
     const errorsPais = checkForErrors("Pais", country, expectationsPais, countryRef);
     const errorsInicial = checkForErrors("Cantidad inicial", parseInt(inicial), expectationsInicial, inicialRef);
-    const errorInputs = [errorsBook, errorsBookstore, errorsPais, errorsInicial];
+    // const errorInputs = [errorsBook, errorsBookstore, errorsPais, errorsInicial];
+    const errorInputs = [errorsBookstore, errorsPais, errorsInicial];
     for (const errorInput of errorInputs) {
       if (errorInput.length > 0) {
         errorsList.push(errorInput);
@@ -259,13 +260,13 @@ function EditInventoryModal({ clickedRow, closeModal, pageIndex, globalFilter}) 
         <p>Editar inventario</p>
       </div>
       <form className="global-form">
-        <select onChange={(e) => dropDownChange(e, "Book")}
+        {/* <select onChange={(e) => dropDownChange(e, "Book")}
           className="select-global" ref={bookRef}>
           <option value={book}>{book}</option>
           {existingBooks && existingBooks.map((book, index) => (
             <option key={index} value={book.title}>{book.title}</option>
           ))}
-        </select>
+        </select> */}
         <select onChange={(e) => dropDownChange(e, "Bookstore")}
           className="select-global" ref={bookstoreRef}>
           <option value={bookstore}>{bookstore}</option>

--- a/frontend/src/InventoriesProvider.jsx
+++ b/frontend/src/InventoriesProvider.jsx
@@ -6,7 +6,6 @@ function InventoriesProvider({ children }) {
   const [inventories, setInventories] = useState("");
 
   async function fetchInventories() {
-    console.log(baseURL);
     try {
       const response = await fetch(`${baseURL}/admin/inventories`, {
         method: "GET",


### PR DESCRIPTION
- Removed the possibility to add an inventory. An inventory is now only created through a transfer or a new book.
- Fixed an issue where you could make a transfer to the same inventory, creating disponibility out of nowhere. 
- Fixed an issue where opening the transfer modal would not reset the type to inventory later, which would stop you from opening inventory modals afterwards.