### PR TITLE
Refactoring of inventories fetching  / cleanup details

### DIFF
--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -722,65 +722,188 @@ router.get('/inventories', async (req, res) => {
   }
 });
 
-// router.post('/inventory', async (req, res) => {
-//   try {
-//     const {
-//       book,
-//       bookstore,
-//       country,
-//       inicial
-//     } = req.body;
-//     const existing = await prisma.inventory.findUnique({
-//       where: {
-//         bookId_bookstoreId_country: {
-//           bookId: book,
-//           bookstoreId: bookstore,
-//           country: country
-//         }
-//       }
-//     });
+router.get('/inventoriesByBook', async (req, res) => {
+  try {
+    const queryBookId = parseInt(req.query.bookId);
+    const thatBookImpressions = await prisma.impression.findMany({
+      where: {
+        bookId: queryBookId,
+        isDeleted: false
+      },
+      select: {
+        id: true,
+        quantity: true,
+        note: true,
+        isDeleted: true,
+        createdAt: true
+      }
+    })
 
-//     if (existing) {
-//       if (existing.isDeleted === false) {
-//         res.status(500).json({message: "Este inventario ya existe"})
-//         return;
-//       }
+    const thatBookInventories = await prisma.inventory.findMany({
+      where: {
+        bookId: queryBookId,
+        isDeleted: false
+      },
+      select: {
+        bookstore: {
+          select: {
+            name: true
+          }
+        },
+        bookstoreId: true,
+        country: true,
+        initial: true,
+        current: true,
+        returns: true,
+        givenToAuthor: true,
+        sales: {
+          select: {
+            quantity: true,
+            isDeleted: true
+          }
+        }
+      }
+    })
 
-//       const exhumedInventory = await prisma.inventory.update({
-//         where: {id: existing.id},
-//         data: {
-//           bookId: book,
-//           bookstoreId: bookstore,
-//           country: country,
-//           initial: inicial,
-//           current: inicial,
-//           isDeleted: false
-//         }
-//       });
-//       res.status(201).json(exhumedInventory);
-//       return;
-//     }
+    const relevantInventories = [];
+    let currentTotal = 0;
+    let initialTotal = 0;
+    let returnsTotal = 0;
+    let givenToAuthorTotal = 0;
+    let soldTotal = 0;
+    for (const inventory of thatBookInventories) {
+      let thisInventorySalesTotal = 0
+      currentTotal += inventory.current;
+      initialTotal += inventory.initial;
+      returnsTotal += inventory.returns;
+      givenToAuthorTotal += inventory.givenToAuthor;
+      for (const sale of inventory.sales) {
+        if (sale.isDeleted === false) {
+          soldTotal += sale.quantity
+          thisInventorySalesTotal += sale.quantity
+        }
+      }
+      const inventoryPlusSales = {...inventory, totalSales: thisInventorySalesTotal}
+      relevantInventories.push(inventoryPlusSales);
+    }
+    const sortedRelevantInventories = relevantInventories.sort((a, b) => b.current - a.current);
+    const payload = {
+      sortedRelevantInventories,
+      currentTotal,
+      initialTotal,
+      returnsTotal,
+      givenToAuthorTotal,
+      soldTotal,
+      thatBookImpressions
+    }
 
-//     const createdInventory = await prisma.inventory.create({
-//       data: {
-//         bookId: book,
-//         bookstoreId: bookstore,
-//         country: country,
-//         initial: inicial,
-//         current: inicial
-//       }
-//     });
-//     res.status(201).json(createdInventory);
-//   } catch (error) {
-//     console.error(error);
-//     if (String(error).includes(("Unique constraint failed on the fields: (`bookId`,`bookstoreId`,`country`)"))) {
-//       res.status(500).json({message: "Este inventario ya existe"})
-//       return;
-//     }
+    res.status(200).json(payload);
 
-//     res.status(500).json({ error: error });
-//   }
-// })
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({error: "Server error at inventoriesByBook route"});
+  }
+})
+
+router.get('/inventoriesByBookstore', async (req, res) => {
+  try {
+    const queryBookstoreId = parseInt(req.query.bookstoreId);
+
+    const thatBookstoreInventories = await prisma.inventory.findMany({
+      where: {
+        bookstoreId: queryBookstoreId,
+        isDeleted: false
+      },
+      select: {
+        book: {
+          select: {
+            title: true
+          }
+        },
+        bookId: true,
+        country: true,
+        initial: true,
+        current: true,
+        returns: true,
+        givenToAuthor: true,
+        sales: {
+          select: {
+            quantity: true,
+            isDeleted: true
+          }
+        }
+      }
+    })
+
+    const relevantInventories = [];
+    let currentTotal = 0;
+    let initialTotal = 0;
+    let returnsTotal = 0;
+    let givenToAuthorTotal = 0;
+    let soldTotal = 0;
+    for (const inventory of thatBookstoreInventories) {
+      let thisInventorySalesTotal = 0
+      currentTotal += inventory.current;
+      initialTotal += inventory.initial;
+      returnsTotal += inventory.returns;
+      givenToAuthorTotal += inventory.givenToAuthor;
+      for (const sale of inventory.sales) {
+        if (sale.isDeleted === false) {
+          soldTotal += sale.quantity
+          thisInventorySalesTotal += sale.quantity
+        }
+      }
+      const inventoryPlusSales = {...inventory, totalSales: thisInventorySalesTotal}
+      relevantInventories.push(inventoryPlusSales);
+    }
+    const sortedRelevantInventories = relevantInventories.sort((a, b) => b.current - a.current);
+    const payload = {
+      sortedRelevantInventories,
+      currentTotal,
+      initialTotal,
+      returnsTotal,
+      givenToAuthorTotal,
+      soldTotal,
+    }
+
+    res.status(200).json(payload);
+
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({error: "Server error at inventoriesByBook route"});
+  }
+})
+
+router.get('/inventoriesCurrentTotals', async (req, res) => {
+  try {
+    const currentTotals = await prisma.inventory.groupBy({
+      by: ['bookstoreId'],
+      _sum: {
+        current: true
+      }
+    })
+
+    const withNames = await Promise.all(
+      currentTotals.map(async (group) => {
+        const bookstore = await prisma.bookstore.findUnique({
+          where: { id: group.bookstoreId },
+          select: { name: true }
+        });
+
+        return {
+          ...group,
+          bookstoreName: bookstore?.name || null
+        };
+      })
+    );
+
+    res.status(200).json(withNames);
+
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({error: "Server error at inventoriesCurrentTotals route"});
+  }
+})
 
 router.patch('/inventory', async (req, res) => {
   try {

--- a/frontend/src/AddingCategoryError.jsx
+++ b/frontend/src/AddingCategoryError.jsx
@@ -17,10 +17,14 @@ function AddingCategoryError({errorList, setErrorList}) {
         return (<p className="login-error">El percentage de regalias debe estar un numero.</p>)
       case 22:
         return (<p className="login-error">El percentage de regalias no puede estar vacío.</p>)
+      case 23:
+        return (<p className="login-error">El percentage de regalias no puede ser mas de 100.</p>)
       case 31:
         return (<p className="login-error">El percentage de gestion de tiendas debe estar un numero.</p>)
       case 32:
         return (<p className="login-error">El percentage de gestion de tiendas no puede estar vacío.</p>)
+      case 33:
+        return (<p className="login-error">El percentage de gestion de tiendas no puede ser mas de 100.</p>)
       case 41:
         return (<p className="login-error">El minima de gestion debe estar un numero.</p>)
       case 42:

--- a/frontend/src/AddingCategoryModal.jsx
+++ b/frontend/src/AddingCategoryModal.jsx
@@ -93,6 +93,11 @@ function AddingCategoryModal({ clickedRow, closeModal, pageIndex, globalFilter }
       addErrorClass(inputRegalias);
     };
 
+    if (parseFloat(regalias) > 100) {
+      newErrorList.push(23);
+      addErrorClass(inputRegalias);
+    }
+
     if (isNaN(parseFloat(gestionTiendas))) {
       newErrorList.push(31);
       addErrorClass(inputGestionTiendas);
@@ -102,6 +107,11 @@ function AddingCategoryModal({ clickedRow, closeModal, pageIndex, globalFilter }
       newErrorList.push(32);
       addErrorClass(inputGestionTiendas);
     };
+
+    if (parseFloat(gestionTiendas) > 100) {
+      newErrorList.push(33);
+      addErrorClass(inputGestionTiendas);
+    }
 
     if (isNaN(parseFloat(gestionMinima))) {
       newErrorList.push(41);

--- a/frontend/src/AdminNavbar.jsx
+++ b/frontend/src/AdminNavbar.jsx
@@ -53,7 +53,7 @@ function AdminNavbar({
     //   return;
     // };
 
-    if (active === "inventories2") {
+    if (active === "inventories") {
       searchBarRef.current.focus();
       return;
     }
@@ -92,7 +92,7 @@ function AdminNavbar({
   }, [inventories])
 
   useEffect(() => {
-    if (active === "inventories2") {
+    if (active === "inventories") {
       searchBarRef.current.classList.add("navbar-extended");
     }
   }, [active]);
@@ -125,7 +125,7 @@ function AdminNavbar({
       <Link to='/admin/bookstores' className="navbar-button">Librerías</Link>
       <Link to='/admin/categories' className="navbar-button">Categorias</Link>
       {/* <Link to='/admin/inventories' className="navbar-button">Inventarios</Link> */}
-      {active === "inventories2" ?
+      {active === "inventories" ?
         <>
           <input
             type="text"
@@ -151,7 +151,7 @@ function AdminNavbar({
             null
           }
         </>:
-        <Link to='/admin/inventories2' className="navbar-button">Inventarios</Link>
+        <Link to='/admin/inventories' className="navbar-button">Inventarios</Link>
       }
       <Link to='/admin/sales' className="navbar-button">Ventas</Link>
     </div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -32,7 +32,7 @@ function App() {
           <Route path='/admin/authors' element={<AuthorsList />} />
           <Route path="/admin/categories" element={<CategoriesList />} />
           {/* <Route path="/admin/inventories" element={<InventoriesList />} /> */}
-          <Route path="/admin/inventories2" element={<InventoriesAreaDashboard />} />
+          <Route path="/admin/inventories" element={<InventoriesAreaDashboard />} />
           <Route path="/admin/bookstoreInventory" element={<BookstoreInventory />} />
           <Route path="/admin/bookInventory" element={<BookInventory />} />
           <Route path="/admin/sales" element={<SalesList />} />

--- a/frontend/src/AuthorInventory.jsx
+++ b/frontend/src/AuthorInventory.jsx
@@ -10,7 +10,7 @@ import GivenToAuthorDetails from "./GivenToAuthorDetails";
 import AuthorBookstoreInventory from "./AuthorBookstoreInventory";
 import AuthorWasInventory from "./AuthorWasInventory";
 import AuthorAvailableInventory from "./AuthorAvailableInventory";
-import AuthorInventoryGlobal from "./AuthorInventoryGlobal";
+// import AuthorInventoryGlobal from "./AuthorInventoryGlobal";
 import AuthorTrialInventory from "./AuthorTrialInventory";
 
 function AuthorInventory(){
@@ -35,14 +35,14 @@ function AuthorInventory(){
   const legendValues = [
     ['Entregados al autor', '#57eafa'],
     ['Vendidos', '#4E5981'],
+    ['Devoluciones', 'black'],
     ['Disponibles', '#E2E2E2'],
-    ['Devoluciones', 'black']
   ]
   const [legendDisplays, setLegendDisplays] = useState({
     'givenToAuthor': true,
     'sold': true,
-    'current': true,
-    'returns': true
+    'returns': true,
+    'current': true
   });
 
   useEffect(()=>{

--- a/frontend/src/AuthorInventoryGlobal.jsx
+++ b/frontend/src/AuthorInventoryGlobal.jsx
@@ -1,6 +1,6 @@
 import XAxis from "./XAxis";
 import { useState, useEffect } from "react";
-import "./AuthorInventoryGlobal.scss";
+
 import OverlappingHorizontalGraphLines from "./OverlappingHorizontalGraphLines";
 import Legend from "./Legend";
 

--- a/frontend/src/AuthorSales.jsx
+++ b/frontend/src/AuthorSales.jsx
@@ -59,6 +59,9 @@ function AuthorSales() {
     });
 
     const sortedData = Object.values(monthlySales).sort((a, b) => a.month.localeCompare(b.month));
+    for (const month of sortedData) {
+      month.value = (month.value).toFixed(2);
+    }
     setMonthlyData(sortedData);
   }
 

--- a/frontend/src/AuthorTrialInventory.jsx
+++ b/frontend/src/AuthorTrialInventory.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import OverlappingHorizontalGraphLines from "./OverlappingHorizontalGraphLines";
 import ScopeSelector from "./ScopeSelector";
 import "./AuthorTrialInventory.scss";
+import "./AuthorInventoryGlobal.scss";
 import Legend from "./Legend";
 
 function AuthorTrialInventory({
@@ -44,6 +45,8 @@ function AuthorTrialInventory({
   useEffect(() => {
     fetchAllAuthorInventories();
   }, []);
+
+  console.log(data);
 
   function filterData(data, scope, selectedBookId, legendDisplays, exclusions) {
     if (!data) {
@@ -118,7 +121,8 @@ function AuthorTrialInventory({
           current: inventory.current,
           givenToAuthor: inventory.givenToAuthor,
           returns: inventory.returns,
-          sold: sumSales
+          sold: sumSales,
+          color: scope === "bookstore" ? inventory.bookstore.color : '#E2E2E2'
         }
       }
     }
@@ -204,11 +208,11 @@ function AuthorTrialInventory({
         <OverlappingHorizontalGraphLines
           key={index}
           title={dataPoint[0]}
-          initial={legendDisplays['initial'] && dataPoint[1].initial}
+          color={dataPoint[1].color}
           sold={legendDisplays['sold'] && dataPoint[1].sold}
           given={legendDisplays['givenToAuthor'] && dataPoint[1].givenToAuthor}
-          current={legendDisplays['current'] && dataPoint[1].current}
           returns={legendDisplays['returns'] && dataPoint[1].returns}
+          current={legendDisplays['current'] && dataPoint[1].current}
           max={max} />))}
       <Legend
         values={legendValues}

--- a/frontend/src/BookInventory.jsx
+++ b/frontend/src/BookInventory.jsx
@@ -1,6 +1,5 @@
 import useCheckAdmin from "./customHooks/useCheckAdmin";
-import { useEffect, useRef, useState, useMemo, useContext } from "react";
-import InventoriesContext from "./InventoriesContext";
+import { useEffect, useRef, useState, useMemo } from "react";
 import InventoryTotal from "./InventoryTotal";
 import { MaterialReactTable, useMaterialReactTable } from 'material-react-table';
 import TableActions from "./TableActions";
@@ -16,7 +15,6 @@ function BookInventory({
     setRetreat}) {
   useCheckAdmin()
   const baseURL = import.meta.env.VITE_API_URL || '';
-  const { inventories, fetchInventories } = useContext(InventoriesContext);
   const [currentTotal, setCurrentTotal] = useState(0);
   const [initialTotal, setInitialTotal] = useState(0);
   const [returnsTotal, setReturnsTotal] = useState(0);
@@ -232,41 +230,36 @@ function BookInventory({
     }
   });
 
-  useEffect(() => {
-    if (!inventories) {
-      fetchInventories();
-    }
-    selectRelevantInventories();
-  }, [inventories])
+  async function getBookInventories() {
+    try {
+      const response = await fetch(`${baseURL}/admin/inventoriesByBook?bookId=${selectedBookId}`, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        credentials: "include"
+      });
 
-  function selectRelevantInventories() {
-    const relevantInventories = [];
-    let currentTotal = 0;
-    let initialTotal = 0;
-    let returnsTotal = 0;
-    let givenToAuthorTotal = 0;
-    let soldTotal = 0;
-    for (const inventory of inventories) {
-      if (inventory.book.title === selectedBook) {
-        relevantInventories.push(inventory);
-        currentTotal += inventory.current;
-        initialTotal += inventory.initial;
-        returnsTotal += inventory.returns;
-        givenToAuthorTotal += inventory.givenToAuthor;
-        for (const sale of inventory.sales) {
-          soldTotal += sale.quantity
-        }
+      if (response.ok) {
+        const data = await response.json();
+        console.log(data);
+        setData(data.sortedRelevantInventories);
+        setCurrentTotal(data.currentTotal);
+        setInitialTotal(data.initialTotal);
+        setSoldTotal(data.soldTotal);
+        setGivenToAuthorTotal(data.givenToAuthorTotal);
+        setReturnsTotal(data.returnsTotal);
+        setImpressions(data.thatBookImpressions);
       }
+
+    } catch (error) {
+      console.log(error)
     }
-    setCurrentTotal(currentTotal);
-    setInitialTotal(initialTotal);
-    setReturnsTotal(returnsTotal);
-    setGivenToAuthorTotal(givenToAuthorTotal);
-    setSoldTotal(soldTotal);
-    const sortedRelevantInventories = relevantInventories.sort((a, b) => b.current - a.current);
-    setData(sortedRelevantInventories);
-    setImpressions(sortedRelevantInventories[0].book.impressions);
   }
+
+  useEffect(() => {
+    getBookInventories();
+  }, []);
 
   useEffect(() => {
     requestAnimationFrame(() => {
@@ -298,7 +291,7 @@ function BookInventory({
     setTableActionsOpen(prev => !prev);
     globalFilter && setGlobalFilter(globalFilter);
     if (reload === true) {
-      fetchInventories();
+      getBookInventories();
       setForceRender(!forceRender);
     }
     if (alertMessage) {

--- a/frontend/src/BookstoreInventory.jsx
+++ b/frontend/src/BookstoreInventory.jsx
@@ -1,8 +1,6 @@
-import { useContext, useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import useCheckAdmin from './customHooks/useCheckAdmin';
-import InventoriesContext from "./InventoriesContext";
 import "./BookstoreInventory.scss";
-// import BookstoreInventoryBook from "./BookstoreInventoryBook";
 import InventoryTotal from "./InventoryTotal";
 import { MaterialReactTable, useMaterialReactTable } from 'material-react-table';
 import TableActions from "./TableActions";
@@ -13,12 +11,12 @@ import ProgressBar from "./ProgressBar";
 function BookstoreInventory({
     selectedBookstore,
     selectedBookstoreNoSpaces,
+    selectedBookstoreId,
     selectedLogo,
     isBookstoreInventoryOpen,
     setBookstoreInventoryOpen}) {
   useCheckAdmin();
   const baseURL = import.meta.env.VITE_API_URL || '';
-  const { inventories, fetchInventories } = useContext(InventoriesContext);
   const [data, setData] = useState([]);
   const bookstoreInventoryRef = useRef()
   const [currentTotal, setCurrentTotal] = useState(0);
@@ -238,13 +236,6 @@ function BookstoreInventory({
     }
   });
 
-  useEffect(() => {
-    if (!inventories) {
-      fetchInventories();
-    }
-    selectRelevantInventories();
-  }, [inventories])
-
   // ensures the modalType is reset to the correct one after you add a transfer
   useEffect(() => {
     if (!isModalOpen) {
@@ -252,33 +243,37 @@ function BookstoreInventory({
     }
   }, [modalType, isModalOpen])
 
-  function selectRelevantInventories() {
-    const relevantInventories = [];
-    let currentTotal = 0;
-    let initialTotal = 0;
-    let returnsTotal = 0;
-    let givenToAuthorTotal = 0;
-    let soldTotal = 0;
-    for (const inventory of inventories) {
-      if (inventory.bookstore.name === selectedBookstore) {
-        relevantInventories.push(inventory);
-        currentTotal += inventory.current;
-        initialTotal += inventory.initial;
-        returnsTotal += inventory.returns;
-        givenToAuthorTotal += inventory.givenToAuthor;
-        for (const sale of inventory.sales) {
-          soldTotal += sale.quantity
-        }
+  async function getBookstoreInventories() {
+    try {
+      const response = await fetch(`${baseURL}/admin/inventoriesByBookstore?bookstoreId=${selectedBookstoreId}`, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        credentials: "include"
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        console.log(data);
+        setData(data.sortedRelevantInventories);
+        setCurrentTotal(data.currentTotal);
+        setInitialTotal(data.initialTotal);
+        setSoldTotal(data.soldTotal);
+        setGivenToAuthorTotal(data.givenToAuthorTotal);
+        setReturnsTotal(data.returnsTotal);
       }
+
+    } catch (error) {
+      console.log(error)
     }
-    setCurrentTotal(currentTotal);
-    setInitialTotal(initialTotal);
-    setReturnsTotal(returnsTotal);
-    setGivenToAuthorTotal(givenToAuthorTotal);
-    setSoldTotal(soldTotal);
-    const sortedRelevantInventories = relevantInventories.sort((a, b) => b.current - a.current);
-    setData(sortedRelevantInventories);
   }
+
+  useEffect(() => {
+    getBookstoreInventories();
+  }, []);
+
+  console.log(selectedBookstoreId)
 
   useEffect(() => {
     requestAnimationFrame(() => {
@@ -311,7 +306,7 @@ function BookstoreInventory({
     setTableActionsOpen(prev => !prev);
     globalFilter && setGlobalFilter(globalFilter);
     if (reload === true) {
-      fetchInventories();
+      getBookstoreInventories();
       setForceRender(!forceRender);
     }
     if (alertMessage) {

--- a/frontend/src/EditCategoryModal.jsx
+++ b/frontend/src/EditCategoryModal.jsx
@@ -93,6 +93,11 @@ function EditCategoryModal({ clickedRow, closeModal, pageIndex, globalFilter }) 
       addErrorClass(inputRegalias);
     };
 
+    if (parseFloat(regalias) > 100) {
+      newErrorList.push(23);
+      addErrorClass(inputRegalias);
+    }
+
     if (isNaN(parseFloat(gestionTiendas))) {
       newErrorList.push(31);
       addErrorClass(inputGestionTiendas);
@@ -102,6 +107,11 @@ function EditCategoryModal({ clickedRow, closeModal, pageIndex, globalFilter }) 
       newErrorList.push(32);
       addErrorClass(inputGestionTiendas);
     };
+
+    if (parseFloat(gestionTiendas) > 100) {
+      newErrorList.push(33);
+      addErrorClass(inputGestionTiendas);
+    }
 
     if (isNaN(parseFloat(gestionMinima))) {
       newErrorList.push(41);

--- a/frontend/src/InventoriesAreaDashboard.jsx
+++ b/frontend/src/InventoriesAreaDashboard.jsx
@@ -22,6 +22,7 @@ function InventoriesAreaDashboard() {
   const [isBookInventoryOpen, setBookInventoryOpen] = useState(false);
   const [isBookstoreInventoryOpen, setBookstoreInventoryOpen] = useState(false);
   const [selectedBookstore, setSelectedBookstore] = useState("");
+  const [selectedBookstoreId, setSelectedBookstoreId] = useState(null);
   const [selectedBook, setSelectedBook] = useState("");
   const [selectedBookstoreNoSpaces, setSelectedBookstoreNoSpaces] = useState("");
   const [selectedLogo, setSelectedLogo] = useState("");
@@ -39,22 +40,37 @@ function InventoriesAreaDashboard() {
     };
   }, []);
 
+  async function getCurrentTotals() {
+    const response = await fetch(`${baseURL}/admin/inventoriesCurrentTotals`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      credentials: "include"
+    });
+
+    if (response.ok) {
+      const data = await response.json()
+      setData(data);
+    }
+  }
+
+  useEffect(() => {
+    getCurrentTotals()
+  }, []);
+
   function getBookstoresNamesandCounts(data) {
     const resCounts = [];
 
-    for (let i = 0; i < data.length; i++) {
-      if (!resCounts[data[i].bookstoreId]) {
-        let bookstoreObject = {
-          name: data[i].bookstore.name,
-          count: data[i].current
-        }
-        resCounts[data[i].bookstoreId] = bookstoreObject;
-      } else {
-        resCounts[data[i].bookstoreId].count += data[i].current
-      }
+    for (const bookstore of data) {
+      resCounts.push({
+          name: bookstore.bookstoreName,
+          count: bookstore._sum.current,
+          id: bookstore.bookstoreId
+        })
     }
 
-    const filteredResCounts = resCounts.filter(count => count !== "");
+    const filteredResCounts = Object.values(resCounts).filter(count => count !== "");
     const sortedResCounts = filteredResCounts.sort((a, b) => b.count - a.count);
 
     setBookstoresCounts(sortedResCounts);
@@ -264,33 +280,10 @@ function InventoriesAreaDashboard() {
     return finalAreaDimensions;
   };
 
-  async function fetchInventories() {
-    try {
-      const response = await fetch(`${baseURL}/admin/inventories`, {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json"
-        },
-        credentials: 'include'
-      })
-
-      if (response.ok) {
-        const data = await response.json();
-        setData(data);
-      }
-    } catch (error) {
-      console.error(error);
-    }
-  }
-
-  useEffect(() => {
-    fetchInventories();
-  }, []);
-
   useEffect(() => {
     const newArray = Array.from({length: bookstoresCounts.length}, () => 0);
     for (const inventory of data) {
-      newArray[inventory.bookstoreId - 1] += parseInt(inventory.current)
+      newArray[inventory.bookstoreId - 1] += inventory._sum.current
     }
     setCurrentQuantities(newArray);
   }, [data, bookstoresCounts]);
@@ -312,7 +305,7 @@ function InventoriesAreaDashboard() {
     <div className="inventory-area-container">
       <Navbar
         subNav={user.role}
-        active={"inventories2"}
+        active={"inventories"}
         setBookstoreInventoryOpen={setBookstoreInventoryOpen}
         setSelectedBookstore={setSelectedBookstore}
         setSelectedBookstoreNoSpaces={setSelectedBookstoreNoSpaces}
@@ -325,6 +318,7 @@ function InventoriesAreaDashboard() {
         <div className="areas-container">
           {areaDimensions && bookstoresCounts && areaDimensions.map((area, index) => {
             const bookstore = bookstoresCounts[index];
+            console.log(bookstore.id);
             const noSpaceName = bookstore.name.replace(' ', '');
             return (
               <InventoryArea
@@ -332,6 +326,7 @@ function InventoriesAreaDashboard() {
                 name={noSpaceName}
                 bookstoreName={bookstore.name}
                 count={bookstore.count}
+                bookstoreId={bookstore.id}
                 top={area.top}
                 left={area.left}
                 height={area.height}
@@ -339,6 +334,7 @@ function InventoriesAreaDashboard() {
                 setBookstoreInventoryOpen={setBookstoreInventoryOpen}
                 setSelectedBookstore={setSelectedBookstore}
                 setSelectedBookstoreNoSpaces={setSelectedBookstoreNoSpaces}
+                setSelectedBookstoreId={setSelectedBookstoreId}
                 setSelectedLogo={setSelectedLogo}
                 retreat={retreat}
                 setRetreat={setRetreat}/>
@@ -350,6 +346,7 @@ function InventoriesAreaDashboard() {
         <BookstoreInventory
           selectedBookstore={selectedBookstore}
           selectedBookstoreNoSpaces={selectedBookstoreNoSpaces}
+          selectedBookstoreId={selectedBookstoreId}
           selectedLogo={selectedLogo}
           isBookstoreInventoryOpen={isBookstoreInventoryOpen}
           setBookstoreInventoryOpen={setBookstoreInventoryOpen}/>}

--- a/frontend/src/InventoryArea.jsx
+++ b/frontend/src/InventoryArea.jsx
@@ -7,6 +7,7 @@ function InventoryArea({
     name,
     bookstoreName,
     count,
+    bookstoreId,
     top,
     left,
     height,
@@ -14,6 +15,7 @@ function InventoryArea({
     setBookstoreInventoryOpen,
     setSelectedBookstore,
     setSelectedBookstoreNoSpaces,
+    setSelectedBookstoreId,
     setSelectedLogo,
     retreat,
     setRetreat}) {
@@ -44,6 +46,7 @@ function InventoryArea({
       setSelectedBookstoreNoSpaces(name);
       setSelectedLogo(logo);
       setBookstoreInventoryOpen(true);
+      setSelectedBookstoreId(bookstoreId)
     }, 250)
   }
 

--- a/frontend/src/Legend.jsx
+++ b/frontend/src/Legend.jsx
@@ -4,8 +4,8 @@ function Legend({values, displays, setDisplays}) {
   const valuesToDisplay = {
     0: "givenToAuthor",
     1: "sold",
-    2: "current",
-    3: "returns"
+    2: "returns",
+    3: "current"
   }
 
   return(

--- a/frontend/src/OverlappingHorizontalGraphLines.jsx
+++ b/frontend/src/OverlappingHorizontalGraphLines.jsx
@@ -1,7 +1,14 @@
 import "./OverlappingHorizontalGraphLines.scss";
 import { useState, useEffect, useRef } from "react";
 
-function OverlappingHorizontalGraphLines({title, initial, sold, given, current, returns, max}) {
+function OverlappingHorizontalGraphLines({
+    title,
+    color,
+    sold,
+    given,
+    current,
+    returns,
+    max}) {
   const [isTitleTooltipOpen, setTitleTooltipOpen] = useState(false);
   const titleRef = useRef();
   const [isEllipsed, setEllipsed] = useState(false);

--- a/frontend/src/SuperAdminNavbar.jsx
+++ b/frontend/src/SuperAdminNavbar.jsx
@@ -58,7 +58,7 @@ function SuperAdminNavbar({
     //   return;
     // }
 
-    if (active === "inventories2") {
+    if (active === "inventories") {
       searchBarRef.current.focus();
       return;
     }
@@ -97,7 +97,7 @@ function SuperAdminNavbar({
   }, [inventories])
 
   useEffect(() => {
-    if (active === "inventories2") {
+    if (active === "inventories") {
       searchBarRef.current.classList.add("navbar-extended");
     }
   }, [active]);
@@ -131,7 +131,7 @@ function SuperAdminNavbar({
       <Link to='/admin/bookstores' className="navbar-button">Librerías</Link>
       <Link to='/admin/categories' className="navbar-button">Categorias</Link>
       {/* <Link to='/admin/inventories' className="navbar-button">Inventarios</Link> */}
-      {active === "inventories2" ?
+      {active === "inventories" ?
         <>
           <input
             type="text"
@@ -157,7 +157,7 @@ function SuperAdminNavbar({
             null
           }
         </>:
-        <Link to='/admin/inventories2' className="navbar-button">Inventarios</Link>
+        <Link to='/admin/inventories' className="navbar-button">Inventarios</Link>
       }
       <Link to='/admin/sales' className="navbar-button">Ventas</Link>
     </div>

--- a/frontend/src/unused/BookstoreInventoryBook.jsx
+++ b/frontend/src/unused/BookstoreInventoryBook.jsx
@@ -1,4 +1,4 @@
-import ProgressBar from "./ProgressBar";
+import ProgressBar from "../ProgressBar";
 
 function BookstoreInventoryBook({title, current, initial}) {
   return(


### PR DESCRIPTION
- Refactored the background use of InventoriesContext so only the relevant info makes it to the client side.
   - InventoriesAreaDashboard now only fetches the sums, names and ids through a new route (inventoriesCurrentTotals)
   - BookstoreInventory and BookInventory only fetch the relevant data for their respective inventories through 2 new routes (inventoriesByBook and inventoriesByBookstores)
- Renamed inventories2 to inventories for cleanup purposes
- Switched returns and current/available in the legend of the interactive graph
- Add a cap to the maximum of percentages in AddingCategory and EditCategory modals