### PR TITLE
Auto-create payments

### DIFF
--- a/backend/jobs/generatePayments.js
+++ b/backend/jobs/generatePayments.js
@@ -1,0 +1,8 @@
+import cron from 'node-cron';
+import { prisma } from "./../server.js";
+
+export async function generatePayments() {
+
+  
+
+}

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "express": "^4.21.2",
         "express-session": "^1.18.1",
         "node": "^18.20.6",
+        "node-cron": "^4.1.0",
         "nodemailer": "^6.10.0",
         "pg": "^8.13.1"
       },
@@ -999,6 +1000,14 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.3.tgz",
       "integrity": "sha512-opgw9iSCAzT2+6wJOETCpeRYAQxSopqQ2z+N6BXwIMsQQ7Zj5M8MaafQY8JMlolRR6R1UXg2WmhKp0p9lSOivg=="
+    },
+    "node_modules/node-cron": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.1.0.tgz",
+      "integrity": "sha512-OS+3ORu+h03/haS6Di8Qr7CrVs4YaKZZOynZwQpyPZDnR3tqRbwJmuP2gVR16JfhLgyNlloAV1VTrrWlRogCFA==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -2417,6 +2426,11 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.3.tgz",
       "integrity": "sha512-opgw9iSCAzT2+6wJOETCpeRYAQxSopqQ2z+N6BXwIMsQQ7Zj5M8MaafQY8JMlolRR6R1UXg2WmhKp0p9lSOivg=="
+    },
+    "node-cron": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.1.0.tgz",
+      "integrity": "sha512-OS+3ORu+h03/haS6Di8Qr7CrVs4YaKZZOynZwQpyPZDnR3tqRbwJmuP2gVR16JfhLgyNlloAV1VTrrWlRogCFA=="
     },
     "node-fetch": {
       "version": "2.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "express": "^4.21.2",
     "express-session": "^1.18.1",
     "node": "^18.20.6",
+    "node-cron": "^4.1.0",
     "nodemailer": "^6.10.0",
     "pg": "^8.13.1"
   },

--- a/backend/prisma/migrations/20250611235056_added_a_default_category_for_each_user/migration.sql
+++ b/backend/prisma/migrations/20250611235056_added_a_default_category_for_each_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "categoryId" SET DEFAULT 1;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -32,13 +32,13 @@ model User {
   referido            String?
   email               String?   @unique
   phone               String?
-  clabe               String?   
+  clabe               String?
   name_bank_account   String?
   bank                String?
   swift               String?
   password            String?
   category            Category? @relation(fields: [categoryId], references: [id])
-  categoryId          Int?
+  categoryId          Int?      @default(1)
   books               Book[]
   role                Role      @default(author)
   reset_password_code Int?

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -4,6 +4,7 @@ import bcrypt from 'bcrypt';
 import { sendSetPasswordMail } from './../mailer.js';
 import { createRandomPassword } from './../utils.js';
 import { prisma } from "./../server.js"
+import { cp } from "fs";
 
 const router = express.Router();
 
@@ -1096,7 +1097,82 @@ router.post('/sale', async (req, res) => {
           current: selectedInventory.current-quantity
         }
       });
-      console.log(updatedInventory);
+
+      // update all potential authors payments sums as well
+      const now = new Date();
+      const year = String(now.getFullYear());
+      const month = String(now.getMonth() + 1).padStart(2, '0');
+      const currentForMonth = year + "-" + month;
+
+      const bookOfSale = await prisma.book.findUnique({
+        where: {
+          id: updatedInventory.bookId
+        },
+        select: {
+          users: {
+            select: {
+              id: true
+            }
+          }
+        }
+      })
+      const userIds = bookOfSale.users.map(user => user.id);
+
+      // update the payment for each author of the book
+      if (userIds.length > 0) {
+        for (const id of userIds) {
+          // using findMany instead of findUnique here to avoid the error if not found.
+          const relatedPayment = await prisma.payment.findMany({
+            where: {
+              userId: id,
+              forMonth: currentForMonth
+            }
+          })
+
+          const userCategory = await prisma.user.findUnique({
+            where: {
+              id: id,
+              isDeleted: false
+            },
+            select: {
+              category: {
+                select: {
+                  percentage_royalties: true,
+                  percentage_management_stores: true
+                }
+              }
+            }
+          })
+
+          if (relatedPayment.length === 0) {
+            const createdPayment = await prisma.payment.create({
+              data: {
+                userId: id,
+                amount: (createdSale.quantity * updatedInventory.price)
+                  * (userCategory.category.percentage_royalties / 100)
+                  * (userCategory.category.percentage_management_stores / 100),
+                forMonth: currentForMonth
+              }
+            })
+          } else {
+            console.log("relatedPayment[0]", relatedPayment[0])
+            console.log("userCategory", userCategory)
+            console.log("createdSale", createdSale)
+            console.log("updatedInventory", updatedInventory)
+            const updatedRelatedPayment = await prisma.payment.update({
+              where: {
+                id: relatedPayment[0].id
+              },
+              data: {
+                amount: relatedPayment[0].amount
+                  + (createdSale.quantity * updatedInventory.price)
+                  * (userCategory.category.percentage_royalties / 100)
+                  * (userCategory.category.percentage_management_stores / 100)
+              }
+            })
+          }
+        }
+      }
     }
 
     res.status(201).json(createdSale);

--- a/frontend/src/AddingSaleModal.jsx
+++ b/frontend/src/AddingSaleModal.jsx
@@ -233,6 +233,7 @@ function AddingSaleModal({clickedRow, closeModal, pageIndex, globalFilter}) {
   }
 
   async function sendToServer() {
+    console.log(book, bookstore);
     try {
       const response = await fetch(`${baseURL}/admin/sale`, {
         method: "POST",
@@ -269,8 +270,8 @@ function AddingSaleModal({clickedRow, closeModal, pageIndex, globalFilter}) {
 
   useEffect(() => {
     if (clickedRow) {
-      setBook(clickedRow.book.title);
-      setBookstore(clickedRow.bookstore.name);
+      setBook(clickedRow.bookId);
+      setBookstore(clickedRow.bookstoreId);
       setCountry(clickedRow.country);
     }
   }, [clickedRow])


### PR DESCRIPTION
- Fixed an issue with adding sales from the book inventory or bookstore inventory as opposed from the sales tab.
- Current payments are now updated with every new sale. Additionally, if a payment for the month doesn't exist yet, a new sale will create it.