### PR TITLE
CRUD Kindle Sales and display in author tabs

### DIFF
--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -3012,6 +3012,57 @@ router.post("/kindlesales", async (req, res) => {
     res.status(200).json({message: "kindleSale created successfully"})
   } catch(error) {
     console.log("Server error at kindlesales ", error);
+    res.status(500).json({error: "Server error while updating the kindle sale"})
+  }
+})
+
+router.patch("/kindlesales/:id", async (req, res) => {
+  try {
+    const kindleSaleIdQuery = parseInt(req.params.id);
+    const bookIdQuery = parseInt(req.body.book);
+    const quantityEbookQuery = parseInt(req.body.quantityEbook);
+    const quantityPodQuery = parseInt(req.body.quantityPod);
+    const dateCutQuery = new Date(req.body.dateCut);
+    const datePayQuery = new Date(req.body.datePay);
+    const regaliasQuery = parseFloat(req.body.regalias);
+
+    const updateKindleSale = await prisma.kindleSale.update({
+      where: {
+        id: kindleSaleIdQuery
+      },
+      data: {
+        bookId : bookIdQuery,
+        quantityEbook: quantityEbookQuery,
+        quantityPod: quantityPodQuery,
+        dateCut: dateCutQuery,
+        datePay: datePayQuery,
+        regalias: regaliasQuery
+      }
+    })
+
+    res.status(200).json({message: "updated kindle sale successfully"})
+  } catch(error) {
+    console.log("Server error at updating kindlesales ", error);
+    res.status(500).json({error: "Server error while updating the kindle sale"})
+  }
+})
+
+router.delete("/kindlesales/:id", async (req, res) => {
+  try {
+    const kindleSaleIdQuery = parseInt(req.params.id);
+    const deletedKindleSale = await prisma.kindleSale.update({
+      where: {
+        id: kindleSaleIdQuery
+      },
+      data: {
+        isDeleted: true
+      }
+    })
+    
+    res.status(200).json({message: "successfully deleted the kindle sale"})
+  } catch(error) {
+    console.log("error at deleting kindlesales ", error);
+    res.status(500).json({error: "Server error while deleting the kindle sale"})
   }
 })
 

--- a/backend/routes/authorRoutes.js
+++ b/backend/routes/authorRoutes.js
@@ -364,45 +364,14 @@ router.get('/sales', async (req, res) => {
     const startDate = req.query.startDate ? new Date(req.query.startDate) : new Date();
     const endDate = req.query.endDate ? new Date(req.query.endDate) : new Date();
 
-    // let sales = await prisma.sale.findMany({
-    //     where: {
-    //       inventory: {
-    //         book: {
-    //           users: {
-    //             some: {
-    //               id: authorId
-    //             }
-    //           }
-    //         }
-    //       },
-    //       createdAt: {
-    //         gte: startDate,
-    //         lte: endDate
-    //       },
-    //       isDeleted: false
-    //     },
-    //     include: {
-    //       inventory: {
-    //         include: {
-    //           book: true,
-    //           bookstore: true
-    //         }
-    //       },
-    //       payments: true
-    //     },
-    //     orderBy: {
-    //       createdAt: 'desc'
-    //     }
-    //   });
-
-    let sales = await prisma.sale.findMany({
+    let allSales = await prisma.sale.findMany({
       where: {
         payments: {
           some: {
             userId: authorId
           }
         },
-        createdAt: {
+        date: {
           gte: startDate,
           lte: endDate
         },
@@ -418,16 +387,14 @@ router.get('/sales', async (req, res) => {
         payments: true
       },
       orderBy: {
-        createdAt: 'desc'
+        date: 'desc'
       }
     });
-
-    // sales = sales.filter(sale => sale.payment.userId === authorId);
 
     let totalSales = 0;
     let totalValue = 0;
     let bookSalesHashMap = {};
-    // let numberOfAuthors = {};
+    let sales = [];
     const author = await prisma.user.findUnique({
       where: {
         id: authorId
@@ -443,19 +410,9 @@ router.get('/sales', async (req, res) => {
       }
     })
 
-    for (const sale of sales) {
-      // if (!numberOfAuthors[sale.inventory.book.title]) {
-      //   const authorCount = await prisma.book.findUnique({
-      //     where: {id: sale.inventory.book.id},
-      //     select: {
-      //       _count: {
-      //         select: {users: true}
-      //       }
-      //     }
-      //   });
-      //   numberOfAuthors[sale.inventory.book.title] = authorCount._count.users;
-      // }
+    
 
+    for (const sale of allSales) {
       const saleValue = calculateAuthorRevenue(
         sale.inventory.bookstore.comissions,
         sale.inventory.price,
@@ -466,6 +423,17 @@ router.get('/sales', async (req, res) => {
 
       totalSales += sale.quantity
       totalValue += saleValue
+      sales.push({
+        id: sale.id,
+        book_id: sale.inventory.book.id,
+        bookstore_id: sale.inventory.bookstore.id,
+        quantity: sale.quantity,
+        date: sale.date,
+        title: sale.inventory.book.title,
+        bookstore_name: sale.inventory.bookstore.name,
+        price: sale.inventory.price,
+        value: saleValue
+      })
 
       if (!bookSalesHashMap[sale.inventory.book.title]) {
         bookSalesHashMap[sale.inventory.book.title] = {
@@ -481,30 +449,62 @@ router.get('/sales', async (req, res) => {
       }
     }
 
+    // NOW ADD KINDLE SALES
+    const authorKindleSales = await prisma.kindleSale.findMany({
+      where: {
+        payments: {
+          some: {
+            userId: authorId
+          }
+        },
+        datePay: {
+          gte: startDate,
+          lte: endDate
+        }, 
+        isDeleted: false
+      }, 
+      include: {
+        payments: true,
+        book: true
+      },
+      orderBy: {
+        datePay: 'desc'
+      }
+    });
+
+    for (const kindleSale of authorKindleSales) {
+      totalSales += kindleSale.quantityEbook + kindleSale.quantityPod;
+      totalValue += kindleSale.regalias
+      sales.push({
+        id: kindleSale.id,
+        book_id: kindleSale.bookId,
+        quantity: (kindleSale.quantityEbook + kindleSale.quantityPod),
+        date: kindleSale.datePay,
+        title: kindleSale.book.title,
+        value: kindleSale.regalias
+      })
+
+      if (!bookSalesHashMap[kindleSale.book.title]) {
+        bookSalesHashMap[kindleSale.book.title] = {
+          "bookId": kindleSale.bookId,
+          "title": kindleSale.book.title,
+          "quantity": (kindleSale.quantityEbook + kindleSale.quantityPod),
+          "value": kindleSale.regalias,
+          // "price": 1
+        }
+      } else {
+        bookSalesHashMap[kindleSale.book.title].quantity += (kindleSale.quantityEbook + kindleSale.quantityPod)
+        bookSalesHashMap[kindleSale.book.title].value += kindleSale.regalias
+      }
+    }
+
     const bookSales = Object.values(bookSalesHashMap);
 
-    res.json({
+    res.status(200).json({
       totalSales,
       totalValue,
       bookSales,
-      sales: sales.map(sale => ({
-        id: sale.id,
-        book_id: sale.inventory.book.id,
-        bookstore_id: sale.inventory.bookstore.id,
-        quantity: sale.quantity,
-        created_at: sale.createdAt,
-        title: sale.inventory.book.title,
-        bookstore_name: sale.inventory.bookstore.name,
-        price: sale.inventory.price,
-        value: calculateAuthorRevenue(
-          sale.inventory.bookstore.comissions,
-          sale.inventory.price,
-          author.category.management_min,
-          sale.inventory.bookstore.deal_percentage,
-          sale.quantity,
-        )
-      }))
-    });
+      sales})
   } catch (error) {
     console.error('Error fetching sales:', error);
     res.status(500).json({ error: 'Internal server error' });
@@ -840,6 +840,22 @@ router.get('/monthlySalesByPayments', async (req, res) => {
             }
           }
         },
+        kindleSales: {
+          select: {
+            book: {
+              select: {
+                title: true
+              }
+            },
+            isDeleted: true,
+            id: true,
+            quantityEbook: true,
+            quantityPod: true,
+            dateCut: true,
+            datePay: true,
+            regalias: true
+          }
+        },
         costs: {
           select: {
             id: true,
@@ -861,7 +877,7 @@ router.get('/monthlySalesByPayments', async (req, res) => {
         "sales": [], 
         "totalQuantity": 0, 
         "totalValue": 0,
-        "costs": []
+        "costs": [],
       }
 
       for (const sale of payment.sales) {
@@ -869,6 +885,8 @@ router.get('/monthlySalesByPayments', async (req, res) => {
           continue;
         }
         
+        /// if we have nothing in the array we start it so that we can go through it 
+        /// with a for loop later on
         if (paymentSales.sales.length === 0) {
           paymentSales.sales.push({
             "title": sale.inventory.book.title,
@@ -903,12 +921,16 @@ router.get('/monthlySalesByPayments', async (req, res) => {
           continue;
         }
 
+        /// if the array isn't empty we go through it to find a matching title
         let existingBook = false;
         for (const entry of paymentSales.sales) {
           if (entry.title === sale.inventory.book.title) {
 
+            // if we match we check if the bookstore for this book has already been included
             let existingBookstore = false;
             for (const bookstore of entry.bookstores) {
+
+              /// if it does we update
               if (bookstore.name === sale.inventory.bookstore.name) {
                   bookstore.quantity += sale.quantity;
                   entry.totalTitleQuantity += sale.quantity;
@@ -921,6 +943,7 @@ router.get('/monthlySalesByPayments', async (req, res) => {
               }
             }
 
+            /// if not we create it
             if (!existingBookstore) {
               entry.bookstores.push({
                 "name": sale.inventory.bookstore.name,
@@ -937,6 +960,7 @@ router.get('/monthlySalesByPayments', async (req, res) => {
                     * (sale.inventory.bookstore.deal_percentage / 100)
               })
 
+              // and we update total quantity and value for the entry
               entry.totalTitleQuantity += sale.quantity;
               entry.totalTitleValue += sale.inventory.bookstore.comissions
                 ? sale.quantity * (sale.inventory.price - user.category.management_min)
@@ -949,6 +973,7 @@ router.get('/monthlySalesByPayments', async (req, res) => {
           }
         }
 
+        // if the book isn't found amongst the entries we create it
         if (!existingBook) {
           paymentSales.sales.push({
             "title": sale.inventory.book.title,
@@ -975,6 +1000,7 @@ router.get('/monthlySalesByPayments', async (req, res) => {
           })
         }
 
+        // and update totalQuantity and totalValue
         paymentSales.totalQuantity += sale.quantity
         paymentSales.totalValue += sale.inventory.bookstore.comissions
           ? sale.quantity * (sale.inventory.price - user.category.management_min)
@@ -990,6 +1016,97 @@ router.get('/monthlySalesByPayments', async (req, res) => {
         }
       }
 
+      //Now we're adding the kindle sales 
+      for (const kindleSale of payment.kindleSales) {
+        if (kindleSale.isDeleted === true) {
+          continue;
+        }
+
+        //same steps than sales
+        // if the month is empty we create it
+        if (paymentSales.sales.length === 0) {
+          paymentSales.sales.push({
+            "title": kindleSale.book.title,
+            "bookstores": [{
+              "name": "Kindle",
+              "quantity": (kindleSale.quantityEbook + kindleSale.quantityPod),
+              "ganancia": kindleSale.regalias,
+              "quantityEbook": kindleSale.quantityEbook,
+              "quantityPod": kindleSale.quantityPod,
+              "dateCut": kindleSale.dateCut,
+              "datePay": kindleSale.datePay,
+              "regalias": kindleSale.regalias
+            }],
+            "totalTitleQuantity": (kindleSale.quantityEbook + kindleSale.quantityPod),
+            "totalTitleValue": kindleSale.regalias
+          })
+
+          paymentSales.totalQuantity += (kindleSale.quantityEbook + kindleSale.quantityPod)
+          paymentSales.totalValue += kindleSale.regalias;
+          continue;
+        }
+
+        /// if the array isn't empty we go through it to find a matching title
+        let existingBook = false;
+        for (const entry of paymentSales.sales) {
+          if (entry.title === kindleSale.book.title) {
+
+            // if we match we check if the bookstore for this book has already been included
+            let existingBookstore = false;
+            for (const bookstore of entry.bookstores) {
+
+              /// if it does we update
+              if (bookstore.name === "Kindle") {
+                  bookstore.quantity += (kindleSale.quantityEbook + kindleSale.quantityPod);
+                  entry.totalTitleQuantity += (kindleSale.quantityEbook + kindleSale.quantityPod);
+                  entry.totalTitleValue += kindleSale.regalias;
+                  existingBookstore = true;
+              }
+            }
+
+            /// if not we create it
+            if (!existingBookstore) {
+              entry.bookstores.push({
+                "name": "Kindle",
+                "quantity": (kindleSale.quantityEbook + kindleSale.quantityPod),
+                "ganancia": kindleSale.regalias,
+                "quantityEbook": kindleSale.quantityEbook,
+                "quantityPod": kindleSale.quantityPod,
+                "dateCut": kindleSale.dateCut,
+                "datePay": kindleSale.datePay,
+                "regalias": kindleSale.regalias
+              })
+
+              // and we update total quantity and value for the entry
+              entry.totalTitleQuantity += (kindleSale.quantityEbook + kindleSale.quantityPod);
+              entry.totalTitleValue += kindleSale.regalias
+            }
+            existingBook = true;
+          }
+        }
+
+        if (!existingBook) {
+          paymentSales.sales.push({
+            "title": kindleSale.book.title,
+            "bookstores": [{
+              "name": "Kindle",
+              "quantity": (kindleSale.quantityEbook + kindleSale.quantityPod),
+              "ganancia": kindleSale.regalias,
+              "quantityEbook": kindleSale.quantityEbook,
+              "quantityPod": kindleSale.quantityPod,
+              "dateCut": kindleSale.dateCut,
+              "datePay": kindleSale.datePay,
+              "regalias": kindleSale.regalias
+            }],
+            "totalTitleQuantity": (kindleSale.quantityEbook + kindleSale.quantityPod),
+            "totalTitleValue": kindleSale.regalias
+          })
+        }
+
+        paymentSales.totalQuantity += (kindleSale.quantityEbook + kindleSale.quantityPod)
+        paymentSales.totalValue += kindleSale.regalias
+      }
+      
       monthlySales.push(paymentSales);
     }
     // console.log("monthlySales", monthlySales);
@@ -1469,6 +1586,7 @@ router.get("/payments", async (req, res) => {
       // },
       include: {
         sales: true,
+        kindleSales: true,
         costs: true
       },
       orderBy: {
@@ -1533,6 +1651,7 @@ router.get("/payments", async (req, res) => {
             forMonth: ltmStrings[i],
             status: "created",
             sales: [],
+            kindleSales: [],
             costs: []
           });
         }
@@ -1542,6 +1661,7 @@ router.get("/payments", async (req, res) => {
     //Calculate and add the total amount of each payment
     for (const payment of allPayments) {
       payment.amount = 0;
+      // sales
       if (payment.sales.length > 0) {
         for (const sale of payment.sales) {
           const saleInventory = await prisma.inventory.findUnique({
@@ -1563,6 +1683,14 @@ router.get("/payments", async (req, res) => {
         }
       }
 
+      //kindleSales
+      if (payment.kindleSales.length > 0) {
+        for (const sale of payment.kindleSales) {
+          payment.amount += sale.regalias
+        }
+      }
+
+      //costs
       if (payment.costs.length > 0) {
         for (const cost of payment.costs) {
           payment.amount -= cost.amount

--- a/frontend/src/AuthorComissions.jsx
+++ b/frontend/src/AuthorComissions.jsx
@@ -182,6 +182,8 @@ function AuthorCommissions() {
     fetchSalesByPayments()
   }, [])
 
+  // console.log(salesByPayments);
+
   return(
     <div className="author-commissions"
       style={{ fontSize: `clamp(0.8rem, ${user.font_size}rem, 1.5rem)`}}>

--- a/frontend/src/AuthorInventory.jsx
+++ b/frontend/src/AuthorInventory.jsx
@@ -163,6 +163,7 @@ function AuthorInventory(){
             bookSales={inventories.bookInventories}
             selectedBookId={selectedBookId}/>)}
       </div>
+      <div className="author-inventory-kindle-disclaimer">Este reporte es del inventario físico y no contiene datos de ventas en Kindle*</div>
     </div>
     </div>
   )

--- a/frontend/src/AuthorInventory.scss
+++ b/frontend/src/AuthorInventory.scss
@@ -55,3 +55,7 @@
   // padding: 1rem;
   margin: 1rem;
 }
+
+.author-inventory-kindle-disclaimer {
+  text-align: center;
+}

--- a/frontend/src/AuthorSales.jsx
+++ b/frontend/src/AuthorSales.jsx
@@ -48,7 +48,7 @@ function AuthorSales() {
         : sales.filter(sale => sale.book_id === parseInt(bookId));
 
       filteredSales.forEach(sale => {
-        const date = new Date(sale.created_at);
+        const date = new Date(sale.date);
         const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
 
       if (!monthlySales[monthKey]) {
@@ -137,7 +137,7 @@ function AuthorSales() {
     }
   };
 
-  // console.log(salesData);
+  console.log(salesData);
 
   useEffect(() => {
     if (dateRange !== null) {

--- a/frontend/src/AuthorSales.scss
+++ b/frontend/src/AuthorSales.scss
@@ -76,9 +76,6 @@
   padding: 8px 0;
   border-bottom: 1px solid #eee;
   color: #666;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 #books-sold li:last-child {

--- a/frontend/src/CommissionMonthSelector.jsx
+++ b/frontend/src/CommissionMonthSelector.jsx
@@ -9,6 +9,8 @@ function CommissionMonthSelector({
   preferredFontSize,
   setPaymentInfo}) {
 
+  console.log(payments);
+  
   return(
     <div className="commission-month-selector">
       <div className="cms-title"><h2>Selecciona mes</h2></div>

--- a/frontend/src/DeleteKindleSaleModal.jsx
+++ b/frontend/src/DeleteKindleSaleModal.jsx
@@ -1,0 +1,45 @@
+import useCheckAdmin from "./customHooks/useCheckAdmin";
+
+function DeleteKindleSaleModal({clickedRow, closeModal, pageIndex, globalFilter}) {
+  useCheckAdmin();
+  const baseURL = import.meta.env.VITE_API_URL || '';
+
+  async function deleteKindleSale() {
+    try {
+      const response = await fetch(`${baseURL}/admin/kindlesales/${clickedRow.id}`, {
+        method: "DELETE",
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        credentials: "include",
+      });
+
+      if (response.ok) {
+        const alertMessage = `La venta ha sido eliminada con exito`;
+        closeModal(globalFilter, true, alertMessage, "confirmation");
+      } else {
+        const alertMessage = `No se pudó eliminar la venta.`;
+        closeModal(globalFilter, false, alertMessage, "error");
+      }
+
+    } catch (error) {
+      console.error('Error while deleting sale', error)
+    }
+  }
+  
+  return(
+    <div className="modal-proper">
+      <div className="delmod-confirm">
+        <p>{`¿Está seguro que quiere eliminar esta venta Kindle de ${clickedRow.book.title}?`}</p>
+      </div>
+      <div className="modal-actions">
+        <button className='blue-button modal-button'
+          onClick={() => closeModal(pageIndex, globalFilter, false)}>Cancelar</button>
+        <button className='blue-button modal-button'
+          onClick={deleteKindleSale}>Confirmar</button>
+      </div>
+    </div>
+  )
+}
+
+export default DeleteKindleSaleModal;

--- a/frontend/src/EditKindleSaleModal.jsx
+++ b/frontend/src/EditKindleSaleModal.jsx
@@ -156,16 +156,18 @@ function EditKindleSaleModal({clickedRow, closeModal, pageIndex, globalFilter}) 
     sendToServer()
   }
 
+  console.log(clickedRow)
+
   async function sendToServer() {
     try {
-      const response = await fetch(`${baseURL}/admin/kindlesales`, {
-        method: "POST",
+      const response = await fetch(`${baseURL}/admin/kindlesales/${clickedRow.id}`, {
+        method: "PATCH",
         headers: {
           'Content-Type': 'application/json',
         },
         credentials: "include",
         body: JSON.stringify({
-          book: parseInt(book),
+          book: book,
           quantityEbook: quantityEbook,
           quantityPod: quantityPod,
           dateCut: dateCut,
@@ -192,12 +194,6 @@ function EditKindleSaleModal({clickedRow, closeModal, pageIndex, globalFilter}) 
       console.error(error);
     }
   }
-
-  useEffect(() => {
-    if (clickedRow) {
-      setBook(clickedRow.bookId);
-    }
-  }, [clickedRow])
 
   return (
     <div className="modal-proper">

--- a/frontend/src/InventoryGraph.jsx
+++ b/frontend/src/InventoryGraph.jsx
@@ -54,8 +54,6 @@ function InventoryGraph({
     }
   }
 
-  console.log(data)
-
   // fetch all inventories with relevant data on load
   useEffect(() => {
     fetchAllAuthorInventories();

--- a/frontend/src/KindleDetails.jsx
+++ b/frontend/src/KindleDetails.jsx
@@ -1,0 +1,32 @@
+import "./KindleDetails.scss"
+import { convertISOString } from "../../backend/utils";
+import formatNumber from "./customHooks/formatNumber";
+
+function KindleDetails({bookstore}) {
+  return(
+    <div className="kindle-details">
+      <div className="kindle-details-group">
+        <div className="kindle-details-group-title">Cantidad eBook</div>
+        <div className="kindle-details-group-value">{bookstore.quantityEbook}</div>
+      </div>
+      <div className="kindle-details-group">
+        <div className="kindle-details-group-title">Cantidad PoD</div>
+        <div className="kindle-details-group-value">{bookstore.quantityEbook}</div>
+      </div>
+      <div className="kindle-details-group">
+        <div className="kindle-details-group-title">Fecha de corte</div>
+        <div className="kindle-details-group-value">{bookstore && convertISOString(bookstore.dateCut)}</div>
+      </div>
+      <div className="kindle-details-group">
+        <div className="kindle-details-group-title">Fecha de pago</div>
+        <div className="kindle-details-group-value">{bookstore && convertISOString(bookstore.datePay)}</div>
+      </div>
+      <div className="kindle-details-group">
+        <div className="kindle-details-group-title">Regalias</div>
+        <div className="kindle-details-group-value">{formatNumber(bookstore.regalias)}</div>
+      </div>
+    </div>
+  )
+}
+
+export default KindleDetails;

--- a/frontend/src/KindleDetails.scss
+++ b/frontend/src/KindleDetails.scss
@@ -1,0 +1,9 @@
+.kindle-details {
+  display: flex;
+  margin-top: 0.5rem;
+  justify-content: space-evenly;
+}
+
+.kindle-details-group-title {
+  font-size: 14px;
+}

--- a/frontend/src/Modal.jsx
+++ b/frontend/src/Modal.jsx
@@ -36,6 +36,7 @@ import DeleteCostModal from './DeleteCostModal';
 import EditBookPricesModal from "./EditBookPricesModal";
 import AddingKindleSaleModal from "./AddingKindleSaleModal";
 import EditKindleSaleModal from './EditKindleSaleModal';
+import DeleteKindleSaleModal from './DeleteKindleSaleModal';
 
 function Modal({
   modalType,
@@ -66,7 +67,7 @@ function Modal({
     kindle: {
       adding: AddingKindleSaleModal,
       edit: EditKindleSaleModal,
-      // delete: DeleteKindleSaleModal
+      delete: DeleteKindleSaleModal
     },
     impression: {
       adding: AddingImpressionModal,

--- a/frontend/src/SalesContent.jsx
+++ b/frontend/src/SalesContent.jsx
@@ -33,16 +33,22 @@ const SalesContent = ({
                 <li key={book.bookId}
                   className='books-sold-item'
                   style={{ fontSize: `clamp(0.8rem, ${preferredFontSize}rem, 1.3rem)`}}
-                  title={`${book.title}: ${book.quantity} libros ($ ${formatNumber(book.value)})`}>
-                  {book.title}: {book.quantity} libros <span>({formatNumber(book.value)})</span>
+                  title={`${book.title}: ${book.quantity} libros (${formatNumber(book.value)})`}>
+                    <div>
+                      <div style={{fontWeight: "bold"}}>{book.title}</div>
+                      <div>{book.quantity} libros - <span>{formatNumber(book.value)})</span></div>
+                    </div>
                 </li>
               ))}
             </ul>
             : <ul>
               <li className="books-sold-item"
                 style={{ fontSize: `clamp(0.8rem, ${preferredFontSize}rem, 1.3rem)`}}
-                title={`${selectedBook}: ${selectedBookSales} libros <span>($ ${selectedBookValue.toFixed(2)})</span>`}>
-                {selectedBookTitle}: {selectedBookSales} libros <span>($ {selectedBookValue.toFixed(2)})</span>
+                title={`${selectedBook}: ${selectedBookSales} libros (${formatNumber(selectedBookValue)})`}>
+                <div>
+                  <div style={{fontWeight: "bold"}}>{selectedBookTitle}</div>
+                  <div>{selectedBookSales} libros - <span>{formatNumber(selectedBookValue)}</span></div>
+                </div>
               </li>
             </ul>
           }
@@ -78,12 +84,6 @@ const SalesContent = ({
                 />
               </YAxis>
               <Tooltip 
-                // formatter={(value, name) => {
-                //   if (name === 'Valor de ventas ($)') {
-                //     return [`${formatNumber(value)}`, name]
-                //   }
-                //   return [value, name];
-                // }}
                 content={({ active, payload, label }) => {
                   if (active && payload && payload.length) {
                     const quantity = payload.find(p => p.name === 'Libros vendidos')?.value ?? 0;

--- a/frontend/src/TableBookstoresRowDetails.jsx
+++ b/frontend/src/TableBookstoresRowDetails.jsx
@@ -1,18 +1,66 @@
 import formatNumber from "./customHooks/formatNumber";
+import KindleDetails from "./KindleDetails";
 import './TableBookstoresRowDetails.scss';
+import { useState } from "react";
 
 function TableBookstoresRowDetails({monthlySalesData}) {
+  const [isKindleDetailsOpen, toggleKindleDetailsOpen] = useState(false);
+
+  function openKindleDetails(bookstoreName) {
+    if (bookstoreName !== "Kindle") {
+      return;
+    }
+
+    toggleKindleDetailsOpen(!isKindleDetailsOpen);
+  }
+
   return(
     <div className="table-row-details">
       {monthlySalesData && monthlySalesData.bookstores.map((bookstore, index) => (
-        <div key={index} className="table-row-detail">
-          <div className="tbr-first tbr-title tbrd-name">{bookstore.name}</div>
-          <div className="tbr-name">{bookstore.quantity}</div>
-          <div className="tbr-name">{formatNumber(bookstore.price)}</div>
-          <div className="tbr-name">{!bookstore.isComissions ? bookstore.deal_percentage+"%" : "-"}</div>
-          <div className="tbr-name">{formatNumber(bookstore.comissions)}</div>
-          <div className="tbr-name">{formatNumber(bookstore.ganancia)}</div>
-          <div className="tbr-name">{formatNumber(bookstore.quantity * bookstore.ganancia)}</div>
+        <div key={index} 
+          className={`
+            table-row-detail 
+            ${bookstore.name === "Kindle" && "tbrd-kindle"}
+            `}
+          onClick={() => openKindleDetails(bookstore.name)}>
+          <div className="tbrd-above">
+            <div className={`
+              tbr-first 
+              tbr-title 
+              tbrd-name 
+            `}>{bookstore.name}</div>
+            <div className="tbr-name">{bookstore.quantity}</div>
+            <div className="tbr-name">
+              {bookstore.name === "Kindle" 
+                ? "-"
+                : formatNumber(bookstore.price)}
+            </div>
+            <div className="tbr-name">
+              {bookstore.name === "Kindle"
+                ? "-"
+                : !bookstore.isComissions 
+                  ? bookstore.deal_percentage+"%" 
+                  : "-"}
+            </div>
+            <div className="tbr-name">
+              {bookstore.name === "Kindle" 
+                ? "-"
+                : formatNumber(bookstore.comissions)}
+            </div>
+            <div className="tbr-name">
+              {bookstore.name === "Kindle"
+                ? "-"
+                : formatNumber(bookstore.ganancia)}
+            </div>
+            <div className="tbr-name">
+              {bookstore.name === "Kindle"
+                ? formatNumber(bookstore.ganancia)
+                : formatNumber(bookstore.quantity * bookstore.ganancia)}
+            </div>
+          </div>
+          <div className="tbrd-below">
+            {isKindleDetailsOpen && <KindleDetails bookstore={bookstore}/>}
+          </div>
         </div>
       ))}
     </div>

--- a/frontend/src/TableBookstoresRowDetails.scss
+++ b/frontend/src/TableBookstoresRowDetails.scss
@@ -1,3 +1,12 @@
 .tbrd-name {
   font-style: italic;
 }
+
+.tbrd-kindle {
+  border: 1px solid grey;
+  border-radius: 15px;
+}
+
+.tbrd-kindle:hover {
+  cursor: pointer;
+}

--- a/frontend/src/TableRowDetail.scss
+++ b/frontend/src/TableRowDetail.scss
@@ -1,6 +1,8 @@
 .table-row-detail {
   display: flex;
-  padding: 0 1rem 1rem 1rem;
+  flex-direction: column;
+  padding: 0.5rem;
+  margin: 0.5rem;
   text-align: center;
 }
 
@@ -59,4 +61,9 @@
 
 .tbd-total {
   width: 10%;
+}
+
+
+.tbrd-above {
+  display: flex;
 }


### PR DESCRIPTION
- Finished primary work on edit kindle sale modal.
- Finished primary work on delete kindle sale modal. 
- Kindle Sales now display in authorSales. 
- Adjusted the authorSales recap across titles so that values and sales would always be visible. 
- Added a disclaimer in authorInventory to inform authors that kindleSales are not displayed there. 
- Modified the backend endpoint for authorCommission table to integrate the kindle sales. 
- Modified the backend endpoint for authorCommision month selector to integrate the kindle sales. 
- Modified the tableBookstore in authorCommission to integrate a clickable element displaying the kindle sales details.