### PR TITLE
KindleSales + Costs + various fixes

### DIFF
--- a/backend/prisma/migrations/20251014163916_added_book_relations_to_cost/migration.sql
+++ b/backend/prisma/migrations/20251014163916_added_book_relations_to_cost/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Cost" ADD COLUMN     "bookId" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "Cost" ADD CONSTRAINT "Cost_bookId_fkey" FOREIGN KEY ("bookId") REFERENCES "Book"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20251014164043_made_book_relation_mandatory_for_costs/migration.sql
+++ b/backend/prisma/migrations/20251014164043_made_book_relation_mandatory_for_costs/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - Made the column `bookId` on table `Cost` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Cost" DROP CONSTRAINT "Cost_bookId_fkey";
+
+-- AlterTable
+ALTER TABLE "Cost" ALTER COLUMN "bookId" SET NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Cost" ADD CONSTRAINT "Cost_bookId_fkey" FOREIGN KEY ("bookId") REFERENCES "Book"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20251014222938_clabes_have_to_be_unique/migration.sql
+++ b/backend/prisma/migrations/20251014222938_clabes_have_to_be_unique/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[clabe]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "User_clabe_key" ON "User"("clabe");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -39,7 +39,7 @@ model User {
   email               String?   @unique
   phone               String?
   birthday            String?
-  clabe               String?
+  clabe               String?   @unique
   name_bank_account   String?
   bank                String?
   swift               String?
@@ -70,6 +70,7 @@ model Book {
   updatedAt   DateTime     @updatedAt
   impressions Impression[]
   kindleSales KindleSale[]
+  Cost        Cost[]
 }
 
 model Category {
@@ -198,6 +199,8 @@ model Cost {
   id        Int      @id @default(autoincrement())
   payment   Payment  @relation(fields: [paymentId], references: [id])
   paymentId Int
+  book      Book     @relation(fields: [bookId], references: [id])
+  bookId    Int
   note      String?
   amount    Float
   isDeleted Boolean  @default(false)

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -11,7 +11,9 @@ import {
   getAuthorString 
 } from './../utils.js';
 import { prisma } from "../prisma/client.js"
+import multer from "multer";
 
+const upload = multer();
 const router = express.Router();
 
 // User routes
@@ -147,6 +149,40 @@ router.post('/user', async (req, res) => {
     res.status(500).json({ error: error });
   }
 });
+
+router.post('/addMultiples',  upload.fields([{name: "archivo", maxCount: 1}]), async (req, res) => {
+  try {
+    const csvfile = req.files.archivo[0];
+    const lines = csvfile.split("\n");
+    const errors = [];
+    for (let i = 0; i < lines.length; i++) {
+      const fields = lines[i].split(",");
+      const addedAuthor = await prisma.user.create({
+        data: {
+          first_name: fields[0],
+          last_name: fields[1],
+          country: fields[2],
+          categoryId: fields[3],
+          email: fields[4],
+          phone: fields[5],
+          birthday: fields[6],
+          clabe: fields[7],
+          name_bank_account: fields[8],
+          bank: fields[9],
+          swift: fields[10],
+          referido: fields[11]
+        }
+      })
+      if (!addedAuthor) {
+        errors.push(i)
+      }
+    }
+
+    res.status(200).json({"message": "added multiple authors"});
+  } catch(error) {
+    res.status(500).json({"error": error});
+  }
+})
 
 router.patch('/user', async (req, res) => {
   try {
@@ -2701,7 +2737,13 @@ router.get('/currentCosts', async (req, res) => {
               }
             }
           }
-        }
+        },
+        book: {
+          select: {
+            title: true
+          }
+        },
+        bookId: true
       }
     })
 
@@ -2716,20 +2758,21 @@ router.get('/currentCosts', async (req, res) => {
 
 router.post('/cost', async (req, res) => {
   try {
-    const { 
-      paymentId,
-      amount,
-      note,
-      book
-    } = req.body;
+    let paymentIdQuery; 
+    if (req.body.paymentId !== null) {
+      paymentIdQuery = parseInt(req.body.paymentId);
+    }
+    const amountQuery = parseFloat(req.body.amount);
+    const noteQuery = req.body.note;
+    const bookIdQuery = parseInt(req.body.book);
 
     await prisma.$transaction(async (tx) => {
     // Make sure we got payment Id or Ids
       let paymentIds = [];
-      if (!paymentId) {
+      if (!paymentIdQuery) {
         const selectedBook = await tx.book.findFirst({
           where: {
-            id: parseInt(book),
+            id: bookIdQuery,
             isDeleted: false
           },
           select: {
@@ -2750,11 +2793,6 @@ router.post('/cost', async (req, res) => {
               },
             }
           })
-
-          if (!userPayment.isDeleted && userPayment.status === "created") {
-            paymentIds.push(userPayment.id);
-            continue;
-          }
 
           if (!userPayment) {
             const newPayment = await tx.payment.create({
@@ -2793,9 +2831,14 @@ router.post('/cost', async (req, res) => {
             })
             paymentIds.push(resetPayment.id)
           }
+
+          if (!userPayment.isDeleted && userPayment.status === "created") {
+            paymentIds.push(userPayment.id);
+            continue;
+          }
         }
       } else {
-        paymentIds.push(parseInt(paymentId));
+        paymentIds.push(paymentIdQuery);
       }
 
       // get a new cost for each paymentId
@@ -2803,17 +2846,14 @@ router.post('/cost', async (req, res) => {
         const createdCost = await tx.cost.create({
           data: {
             paymentId: paymentId,
-            amount: parseInt(amount),
-            note: note
+            amount: amountQuery,
+            bookId: bookIdQuery,
+            note: noteQuery
           }
         });
       }
 
-      // if (createdCost) {
       res.status(200).json({message: "Cost created sucessfully"});
-      // } else {
-      //   res.status(500).json({error:"a server error occurred while creating the cost"})
-      // }
     })
     
   } catch (error) {
@@ -2825,46 +2865,21 @@ router.post('/cost', async (req, res) => {
 router.patch("/cost/:id", async (req, res) => {
   try {
     const costId = parseInt(req.params.id);
-    const {
-      amount,
-      note
-    } = req.body;
+    const amountQuery = parseFloat(req.body.amount);
+    const noteQuery = req.body.note;
+    const bookIdQuery = parseInt(req.body.bookId);
 
     await prisma.$transaction(async (tx) => {
-      // const previousCost = await tx.cost.findUnique({
-      //   where: {
-      //     id: costId
-      //   }
-      // })
-      
       const updatedCost = await tx.cost.update({
         where: {
           id: costId
         },
         data: {
-          amount: amount,
-          note: note
+          amount: amountQuery,
+          note: noteQuery,
+          bookId: bookIdQuery
         }
       })
-
-      // if (updatedCost) {
-      //   const previousPayment = await tx.payment.findUnique({
-      //     where: {
-      //       id: updatedCost.paymentId
-      //     }
-      //   });
-
-      //   if (previousPayment) {
-      //     const updatedPayment = await tx.payment.update({
-      //       where: {
-      //         id: updatedCost.paymentId
-      //       },
-      //       data: {
-      //         amount: previousPayment.amount + previousCost.amount - updatedCost.amount
-      //       }
-      //     })
-      //   }
-      // }
     })
 
     res.status(200).json({message: "The cost was updated successfully"});

--- a/backend/routes/authorRoutes.js
+++ b/backend/routes/authorRoutes.js
@@ -1071,6 +1071,7 @@ export async function getMonthlySalesBypayments (req, res) {
               /// if it does we update
               if (bookstore.name === "Kindle") {
                   bookstore.quantity += (kindleSale.quantityEbook + kindleSale.quantityPod);
+                  bookstore.regalias += kindleSale.regalias;
                   entry.totalTitleQuantity += (kindleSale.quantityEbook + kindleSale.quantityPod);
                   entry.totalTitleValue += kindleSale.regalias;
                   existingBookstore = true;
@@ -1700,7 +1701,9 @@ router.get("/payments", async (req, res) => {
       //kindleSales
       if (payment.kindleSales.length > 0) {
         for (const sale of payment.kindleSales) {
-          payment.amount += sale.regalias
+          if (!sale.isDeleted) {
+            payment.amount += sale.regalias
+          }
         }
       }
 

--- a/backend/utils.js
+++ b/backend/utils.js
@@ -240,3 +240,36 @@ export function getAuthorString(userList) {
   }
   return authorString
 }
+
+export function isForMonthNextMonth(forMonth1, forMonth2) {
+  const yearForMonth1 = parseInt(forMonth1.substring(0,4));
+  const yearForMonth2 = parseInt(forMonth2.substring(0,4));
+  const monthForMonth1 = parseInt(forMonth1.substring(5,7));
+  const monthForMonth2 = parseInt(forMonth2.substring(5,7));
+
+  if (monthForMonth2 === 12) {
+    if (monthForMonth1 !== 1) {
+      return false
+    }
+
+    if (yearForMonth1 === yearForMonth2 + 1) {
+      return true
+    } else {
+      return false
+    }
+  }
+
+  if (yearForMonth1 !== yearForMonth2) {
+    return false
+  }
+
+  if (monthForMonth1 !== monthForMonth2 + 1) {
+    return false
+  }
+
+  return true;
+}
+
+export function convertDateStringToLocalFormat(dateString) {
+  return dateString.substring(3,5) + "/"  + dateString.substring(0,2) + "/" + dateString.substring(6,10)
+}

--- a/frontend/src/AddingMultipleAuthorsModal.jsx
+++ b/frontend/src/AddingMultipleAuthorsModal.jsx
@@ -1,0 +1,89 @@
+import './AddingMultipleAuthorsModal.scss';
+import { useState } from "react";
+
+function AddingMultipleAuthorsModal({ clickedRow, closeModal, pageIndex, globalFilter }) {
+  const baseURL = import.meta.env.VITE_API_URL || '';
+  const [archivo, setArchivo] = useState(null);
+  const [errorFile, setErrorFile] = useState("");
+
+  function checkFile(e) {
+    const file = e.target.files[0];
+    if (file && !file.name.endsWith(".csv")) {
+      setErrorFile("El archivo no era de typo .csv")
+    } else {
+      setArchivo(file)
+    }
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    try {
+      const formData = new FormData();
+      formData.append("archivo", archivo)
+
+      const response = await fetch(`${baseURL}/author/addMultiples`, {
+        method: "POST",
+        credentials: "include",
+        body: formData
+      });
+
+      if (response.ok) {
+        const alertMessage = `Multiples autores han estado añadidos con exito.`;
+        closeModal(true, alertMessage, "confirmation");
+      } else {
+        const alertMessage = "No se pudieron añadir multiples autores.";
+        closeModal(false, alertMessage, "error");
+      }
+    } catch(error) {
+      console.log(error)
+    }
+  }
+
+  return (
+    <div className='modal-proper'>
+      <div className='global-form'>
+        <div className="mulauth-adicional-instruciones">
+          <div className="mulauth-top-instrucciones">
+            <p className="mulauth-line">Suba un archivo CSV para añadir multiples autores al mismo tiempo.</p>
+            <p className="mulauth-line">Por favor no incluye el nombre de las columnas en el archivo</p>
+            <p className="mulauth-line">Las columnas deben estar en el siguiente orden:</p>
+          </div>
+          <div className="mulauth-line">
+            <p className="mulauth-line">Nombre*</p>
+            <p className="mulauth-line">Apellido*</p>
+            <p className="mulauth-line">País</p>
+            <p className="mulauth-line">Categoria</p>
+            <p className="mulauth-line">Correo</p>
+            <p className="mulauth-line">Teléfono</p>
+            <p className="mulauth-line">Fecha de nacimiento (dd/mm/aaaa)</p>
+            <p className="mulauth-line">CLABE</p>
+            <p className="mulauth-line">Nombre del titular</p>
+            <p className="mulauth-line">Nombre del banco</p>
+            <p className="mulauth-line">Codigo SWIFT</p>
+            <p className="mulauth-line">Referido</p>
+          </div>
+          <div className="mulauth-bottom-instrucciones">
+            <p className="mulauth-line">*mandatorios</p>
+          </div>
+          
+        </div>
+        <div className="modal-form-upload">
+          <label className="modal-form-label">Archivo CSV</label>
+          <input 
+            type='file'
+            className="modal-form-file"
+            accept=".csv"
+            onChange={(e) => checkFile(e)}/>
+          <div className="modal-form-error">{errorFile}</div>
+        </div>
+        <div className="form-actions">
+          <button type="button" className='blue-button'
+            onClick={() => closeModal(pageIndex, globalFilter, false)}>Cancelar</button>
+          <button type='button' onClick={handleSubmit} className="blue-button">Añadir</button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default AddingMultipleAuthorsModal;

--- a/frontend/src/AddingMultipleAuthorsModal.scss
+++ b/frontend/src/AddingMultipleAuthorsModal.scss
@@ -1,0 +1,18 @@
+.mulauth-adicional-instruciones {
+  text-align: center;
+}
+
+.mulauth-line {
+  margin: 0;
+}
+
+.mulauth-top-instrucciones {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+  font-style: italic;
+}
+
+.mulauth-bottom-instrucciones {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/AdminsList.jsx
+++ b/frontend/src/AdminsList.jsx
@@ -29,6 +29,7 @@ function AdminsList() {
   const columns = useMemo(() => [
     {
       header: "Acciones",
+      size: 50,
       Cell: ({row}) => (
         <div style={{ overflow: "visible" }}>
           <TableActions openModal={openModal} row={row}/>

--- a/frontend/src/AuthorComissions.jsx
+++ b/frontend/src/AuthorComissions.jsx
@@ -8,6 +8,7 @@ import "./AuthorCommissions.scss"
 import Modal from "./Modal";
 import Alert from "./Alert";
 import TableBookstores from "./TableBookstores";
+import { isForMonthNextMonth } from "../../backend/utils";
 
 function AuthorCommissions() {
   useCheckUser();
@@ -53,8 +54,8 @@ function AuthorCommissions() {
         setDemandPaymentPossible("currentMonth");
         return;
       }
-      if (now.getDate() >= 25) {
-        setDemandPaymentPossible("tooLateInTheMonth");
+      if ((isForMonthNextMonth(currentActiveMonth, salesByPayments[activeMonth].forMonth)) && now.getDate() < 10) {
+        setDemandPaymentPossible("tooEarlyInTheNextMonth");
         return;
       }
       setDemandPaymentPossible("available");
@@ -176,12 +177,12 @@ function AuthorCommissions() {
           {isDemandPaymentPossible === "noVentas" && (
             null
           )}
-          {isDemandPaymentPossible === "tooLateInTheMonth" && (
+          {isDemandPaymentPossible === "tooEarlyInTheNextMonth" && (
             <div className="author-commissions-solicitar-pago-unavailable"
               onMouseEnter={() => setDemandPaymentTooltipPossible(true)}
               onMouseLeave={() => setDemandPaymentTooltipPossible(false)}>Solicitar Pago
-              {isDemandPaymentTooltipOpen && (
-                <div className="demand-payment-tooltip">Solicitar un pago es solamente posible antes del 25 del mes</div>)}
+              {/* {isDemandPaymentTooltipOpen && (
+                <div className="demand-payment-tooltip">Solicitar un pago es solamente posible después del 10 del mes</div>)} */}
             </div>
           )}
           {isDemandPaymentPossible === "solicited" && (

--- a/frontend/src/AuthorsList.jsx
+++ b/frontend/src/AuthorsList.jsx
@@ -32,6 +32,7 @@ function AuthorsList() {
   const columns = useMemo(() => [
     {
       header: "Acciones",
+      size: 50,
       Cell: ({row}) => (
         <div style={{overflow:"visible"}}>
           <TableActions openModal={openModal} row={row}/>
@@ -45,31 +46,38 @@ function AuthorsList() {
     },
     {
       header: "Nombre",
+      size: 50,
       accessorKey: "first_name"
     },
     {
       header: "Apellido",
+      size: 50,
       accessorKey: "last_name"
     },
     {
       header: "Pais",
+      size: 50,
       accessorKey: "country"
     },
     {
       header: "Categoria",
+      size: 50,
       accessorFn: (row) => row.category?.type || ''
     },
     {
       header: "Correo",
+      size: 50,
       accessorKey: "email"
     },
     {
       header: "Teléfono",
+      size: 50,
       accessorKey: "phone"
 
     },
     {
       header: "Fecha de nacimiento",
+      size: 50,
       accessorKey: "birthday",
       Cell: ({ row }) => row.original.birthday != null 
         ? `${row.original.birthday.substring(0,2)}/${row.original.birthday.substring(2,4)}/${row.original.birthday.substring(4,8)}`
@@ -77,22 +85,27 @@ function AuthorsList() {
     },
     {
       header: "CLABE",
+      size: 50,
       accessorKey: "clabe"
     }, 
     {
       header: "Nombre del titular",
+      size: 50,
       accessorKey: "name_bank_account"
     },
     {
       header: "Banco",
+      size: 50,
       accessorKey: "bank"
     },
     {
       header: "Codigo Swift",
+      size: 50,
       accessorKey: "swift"
     },
     {
       header: "Referido",
+      size: 50,
       accessorKey: "referido"
     },
   ], []);
@@ -114,6 +127,11 @@ function AuthorsList() {
           className="blue-button"
           style={{ fontSize: `clamp(0.8rem, ${user.font_size}rem, 1.1rem)`}}>
             Añadir nuevo autor</button>
+        <button 
+          className="blue-button"
+          onClick={() => openModal("addingMultiples", null)}
+          style={{ fontSize: `clamp(0.8rem, ${user.font_size}rem, 1.1rem)`}}>
+            Añadir multiples autores</button>
       </div>
     ),
     initialState: {
@@ -177,6 +195,9 @@ function AuthorsList() {
     switch (type) {
       case 'adding':
         setModalAction("adding");
+        break;
+      case 'addingMultiples':
+        setModalAction("addingMultiples");
         break;
       case 'edit':
         setModalAction("edit");

--- a/frontend/src/BookInventory.jsx
+++ b/frontend/src/BookInventory.jsx
@@ -59,6 +59,7 @@ function BookInventory({
   const columns = useMemo(() => [
     {
       header: "Acciones",
+      size: 50,
       Cell: ({row}) => (
         <div style={{overflow:"visible"}}>
           <TableActions

--- a/frontend/src/BooksList.jsx
+++ b/frontend/src/BooksList.jsx
@@ -30,6 +30,7 @@ function BooksList() {
   const columns = useMemo(() => [
     {
       header: "Acciones",
+      size: 50,
       Cell: ({row}) => (
         <div style={{overflow:"visible"}}>
           <TableActions openModal={openModal} row={row} type={"book"}/>

--- a/frontend/src/BookstoreInventory.jsx
+++ b/frontend/src/BookstoreInventory.jsx
@@ -48,6 +48,7 @@ function BookstoreInventory({
   const columns = useMemo(() => [
     {
       header: "Acciones",
+      size: 50,
       Cell: ({row}) => (
         <div style={{position:"relative", overflow:"visible !important"}}>
           <TableActions
@@ -74,6 +75,7 @@ function BookstoreInventory({
     },
     {
       header: "Libro",
+      maxSize: 200,
       accessorKey:'book.title',
       muiTableHeadCellProps: {
         sx: {
@@ -104,6 +106,7 @@ function BookstoreInventory({
     // },
     {
       header: "Inicial",
+      size: 50,
       Cell: ({row}) => {
         return (<div>{row.original.initial}</div>)
       },
@@ -122,6 +125,7 @@ function BookstoreInventory({
     {
       id: "impressions",
       header: "Nuevas impresiónes",
+      size: 50,
       Cell: ({row}) => {
         return (<div>{row.original.extraImpressions}</div>)
       },
@@ -139,6 +143,7 @@ function BookstoreInventory({
     },
     {
       header: "Devueltos",
+      size: 50,
       Cell: ({row}) => (
         <div>{row.original.returns}</div>
       ),
@@ -156,6 +161,7 @@ function BookstoreInventory({
     },
     {
       header: "Vendidos",
+      size: 50,
       Cell: ({row}) => {
         return (<div>{row.original.totalSales}</div>)
       },
@@ -173,6 +179,7 @@ function BookstoreInventory({
     },
     {
       id: "entregasAlAutor",
+      size: 50,
       header: "Entregados al autor",
       Cell: ({row}) => (
         <div>{row.original.givenToAuthor}</div>
@@ -191,6 +198,7 @@ function BookstoreInventory({
     },
     {
       header: "Disponibles",
+      size: 50,
       Cell: ({row}) => (
         <div>{selectedBookstoreId === 3 
           ? row.original.current + row.original.returns

--- a/frontend/src/BookstoresList.jsx
+++ b/frontend/src/BookstoresList.jsx
@@ -30,6 +30,7 @@ function BookstoresList() {
   const columns = useMemo(() => [
     {
       header: "Acciones",
+      size: 50,
       Cell: ({row}) => (
         <div style={{overflow:"visible"}}>
           <TableActions openModal={openModal} row={row}/>
@@ -37,7 +38,7 @@ function BookstoresList() {
       ),
       muiTableBodyCellProps: {
         sx: {
-          overflow: "visible"
+          overflow: "visible",
         }
       }
     },
@@ -120,7 +121,8 @@ function BookstoresList() {
         fontSize: `clamp(0.8rem, ${user.font_size}rem, 1.5rem)`,
         whiteSpace: "nowrap",
         overflow: "hidden",
-        textOverflow: "ellipsis"
+        textOverflow: "ellipsis",
+        maxWidth: 200
       }
     },
     muiTopToolbarProps: {

--- a/frontend/src/CommissionMonthSelector.jsx
+++ b/frontend/src/CommissionMonthSelector.jsx
@@ -8,6 +8,8 @@ function CommissionMonthSelector({
   payments,
   preferredFontSize,
   setPaymentInfo}) {
+
+  console.log(payments);
   
   return(
     <div className="commission-month-selector">

--- a/frontend/src/CostsList.jsx
+++ b/frontend/src/CostsList.jsx
@@ -44,6 +44,10 @@ function CostsLists() {
             },
         },
         {
+            header: "Libro",
+            accessorKey: "book.title"
+        },
+        {
             header: "Autor",
             Cell: ({row}) => (
                 <div>{`${row.original.payment.user.first_name} ${row.original.payment.user.last_name}`}</div>
@@ -167,6 +171,8 @@ function CostsLists() {
             setAlertType(alertType);
         }
     }
+
+    console.log(data)
 
     async function getCurrentCosts() {
         try {

--- a/frontend/src/DemandPaymentModal.jsx
+++ b/frontend/src/DemandPaymentModal.jsx
@@ -6,42 +6,11 @@ import checkForErrors from "./customHooks/checkForErrors";
 import ErrorsList from "./ErrorsList";
 
 function DemandPaymentModal({closeModal, paymentInfo}) {
-  const [uso, setUso] = useState("");
   const [factura, setFactura] = useState(null);
   const [constancia, setConstancia] = useState(null);
   const max_size = 5*1024*1024
-  const usosDeCFDI = [
-    { clave: "G01", descripcion: "Adquisición de mercancías" },
-    { clave: "G02", descripcion: "Devoluciones, descuentos o bonificaciones" },
-    { clave: "G03", descripcion: "Gastos en general" },
-
-    { clave: "I01", descripcion: "Construcciones" },
-    { clave: "I02", descripcion: "Mobiliario y equipo de oficina por inversiones" },
-    { clave: "I03", descripcion: "Equipo de transporte" },
-    { clave: "I04", descripcion: "Equipo de cómputo y accesorios" },
-    { clave: "I05", descripcion: "Dados, troqueles, moldes, matrices y herramental" },
-    { clave: "I06", descripcion: "Comunicaciones telefónicas" },
-    { clave: "I07", descripcion: "Comunicaciones satelitales" },
-    { clave: "I08", descripcion: "Otra maquinaria y equipo" },
-
-    { clave: "D01", descripcion: "Honorarios médicos, dentales y gastos hospitalarios" },
-    { clave: "D02", descripcion: "Gastos médicos por incapacidad o discapacidad" },
-    { clave: "D03", descripcion: "Gastos funerarios" },
-    { clave: "D04", descripcion: "Donativos" },
-    { clave: "D05", descripcion: "Intereses reales efectivamente pagados por créditos hipotecarios" },
-    { clave: "D06", descripcion: "Aportaciones voluntarias al SAR" },
-    { clave: "D07", descripcion: "Primas por seguros de gastos médicos" },
-    { clave: "D08", descripcion: "Gastos de transportación escolar obligatoria" },
-    { clave: "D09", descripcion: "Depósitos en cuentas de ahorro / pensiones" },
-    { clave: "D10", descripcion: "Pagos por servicios educativos (colegiaturas)" },
-
-    { clave: "S01", descripcion: "Sin efectos fiscales" },
-    { clave: "CP01", descripcion: "Pagos" },
-    { clave: "CN01", descripcion: "Nómina" }
-  ]
   const [errorFactura, setErrorFactura] = useState("");
   const [errorConstancia, setErrorConstancia] = useState("");
-  const [errorUso, setErrorUso] = useState("");
   const [correo, setCorreo] = useState("");
   const baseURL = import.meta.env.VITE_API_URL || '';
   const { user } = useContext(UserContext)
@@ -102,15 +71,12 @@ function DemandPaymentModal({closeModal, paymentInfo}) {
       return;
     } 
 
-    if (!factura || !constancia || !uso ) {
+    if (!factura || !constancia ) {
       if (!factura) {
         setErrorFactura("Factura faltante");
       }
       if (!constancia) {
         setErrorConstancia("Constancia faltante");
-      }
-      if (!uso) {
-        setErrorUso("Uso de CFDI faltante");
       }
       return;
     }
@@ -122,7 +88,6 @@ function DemandPaymentModal({closeModal, paymentInfo}) {
       formData.append("month", paymentInfo.month);
       formData.append("monthOriginal", paymentInfo.monthOriginal);
       formData.append("amount", paymentInfo.amount);
-      formData.append("uso", uso);
       formData.append("correo", correo);
 
       const response = await fetch(`${baseURL}/author/sendInvoice`, {
@@ -226,6 +191,11 @@ function DemandPaymentModal({closeModal, paymentInfo}) {
   return (
     <div className="modal-proper">
       <div className="modal-stuff-to-add">
+        <div className="dempay-adicional-info">
+          <p>Por favor, usa el uso de CFDI 551015000 y la referencia venta de libros "título de libro".</p>
+          <p>No añade el IVA en la factura.</p>
+          <p>El pago sera hecho por transferencia.</p>
+        </div>
         <div className="modal-form-upload">
           <label className="modal-form-label dempay-title">Factura (pdf, jpeg, png, max 5MB)</label>
           <input type="file"
@@ -241,17 +211,6 @@ function DemandPaymentModal({closeModal, paymentInfo}) {
             className="modal-form-file"
             onChange={(e) => checkFile(e, "constancia")}/>
           <div className="modal-form-error">{errorConstancia}</div>
-        </div>
-        <div className="modal-form-line">
-          <label className="modal-form-label">Uso de CFDI</label>
-          <select className="select-global dempay-title"
-            onChange={(e) => setUso(e.target.value)}>
-            <option value=""></option>
-            {usosDeCFDI && usosDeCFDI.map((uso, index) => (
-              <option key={index} value={uso.clave}>{uso.clave} : {uso.descripcion}</option>
-            ))}
-          </select>
-          <div className="modal-form-error">{errorUso}</div>
         </div>
         <div className="modal-form-line">
           <label className="modal-form-label">Confirme su correo</label>

--- a/frontend/src/DemandPaymentModal.scss
+++ b/frontend/src/DemandPaymentModal.scss
@@ -12,3 +12,20 @@
   text-align: center;
   padding-bottom: 1rem;
 }
+
+.dempay-adicional-info {
+  margin-bottom: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  align-items: center;
+  border-radius: 15px;
+  background-color: #f8f9fa;
+  padding: 0.5rem;
+}
+
+.dempay-adicional-info p {
+  margin: 0;
+  font-size: 14px;
+}

--- a/frontend/src/EditCostModal.jsx
+++ b/frontend/src/EditCostModal.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import ErrorsList from './ErrorsList';
 import checkForErrors from './customHooks/checkForErrors';
 import useCheckAdmin from './customHooks/useCheckAdmin';
@@ -11,6 +11,32 @@ function EditCostModal({clickedRow, closeModal, pageIndex, globalFilter}) {
     const [note, setNote] = useState(clickedRow.note);
     const noteRef = useRef();
     const [errors, setErrors] = useState([]);
+    const [existingBooks, setExistingBooks] = useState([]);
+    const [selectedBookId, setSelectedBookId] = useState(clickedRow.bookId);
+    const bookRef = useRef();
+
+    async function fetchExistingBooks() {
+        try {
+            const response = await fetch(`${baseURL}/admin/existingBooks`, {
+                method: "GET",
+                headers: {
+                    "Content-Type": "application/json"
+                },
+                credentials: "include"
+            });
+
+            if (response.ok) {
+                const data = await response.json();
+                setExistingBooks(data);
+            }
+        } catch (error) {
+            console.log("Error while fetching existing books:", error);
+        }
+    }
+    
+    useEffect(() => {
+        fetchExistingBooks();
+    }, [])
 
     async function handleSubmit(e) {
         e.preventDefault();
@@ -39,7 +65,8 @@ function EditCostModal({clickedRow, closeModal, pageIndex, globalFilter}) {
 
         const errorsAmount = checkForErrors("El monto", parseFloat(amount), expectationsAmount, amountRef, "o");
         const errorsNote = checkForErrors("La nota", note, expectationsNote, noteRef, "a");
-        const errorInputs = [errorsAmount, errorsNote];
+        const errorsBook = checkForErrors("El libro", parseInt(selectedBookId), expectationsAmount, bookRef, "o");
+        const errorInputs = [errorsAmount, errorsNote, errorsBook];
 
         for (const errorInput of errorInputs) {
             if (errorInput.length > 0) {
@@ -61,7 +88,8 @@ function EditCostModal({clickedRow, closeModal, pageIndex, globalFilter}) {
                 credentials: "include",
                 body: JSON.stringify({
                     amount: parseFloat(amount),
-                    note: note
+                    note: note,
+                    bookId: selectedBookId
                 })
             });
 
@@ -69,7 +97,7 @@ function EditCostModal({clickedRow, closeModal, pageIndex, globalFilter}) {
                 const alertMessage = 'El costo ha estado actualizado con exitó';
                 closeModal(globalFilter, true, alertMessage, "confirmation")
             } else {
-                const alertMessage = 'No se pudó actulizar el costo.';
+                const alertMessage = 'No se pudó actualizar el costo.';
                 closeModal(globalFilter, false, alertMessage, "error")
             }
         } catch (error) {
@@ -86,6 +114,15 @@ function EditCostModal({clickedRow, closeModal, pageIndex, globalFilter}) {
                 <p>*Campos obligatorios</p>
             </div>
             <form className="global-form">
+                <select className="select-global"
+                    ref={bookRef}
+                    value={selectedBookId}
+                    onChange={(e) => setSelectedBookId(e.target.value)}>
+                    <option value="">Selecciona libro*</option>
+                    {existingBooks && existingBooks.map((book, index) => (
+                        <option key={index} value={book.id}>{book.title}</option>
+                    ))}
+                </select>
                 <div className="modal-form-line">
                     <label className="modal-form-label">Monto *</label>
                     <input type="text"

--- a/frontend/src/InventoriesList.jsx
+++ b/frontend/src/InventoriesList.jsx
@@ -60,6 +60,7 @@ function InventoriesList() {
     {
       header: "Nombre",
       accessorKey: "name",
+      maxSize: 200,
       Cell: ({row}) => (
         <div
           onClick={() => openSpecifics(row.original.type, row.original.id)}
@@ -70,18 +71,22 @@ function InventoriesList() {
     },
     {
       header: "Inicial",
+      size: 100,
       accessorKey: "initial",
     },
     {
       header: "Impresiónes",
+      size: 100,
       accessorKey: "extraImpressions",
     },
     {
       header: "Vendidos",
+      size: 100,
       accessorKey: "sold",
     },
     {
       header: "Devueltos",
+      size: 100,
       // accessorKey: "returns",
       Cell: ({row}) => (
         // <div>{row.original.id === 1 
@@ -92,10 +97,12 @@ function InventoriesList() {
     },
     {
       header: "Entregados al autor",
+      size: 100,
       accessorKey: "givenToAuthor"
     },
     {
       header: "Disponibles",
+      size: 100,
       Cell: ({row}) => (
         <div>{row.original.id === 1 ? 
           row.original.initial - row.original.sold + row.original.returns - row.original.givenToAuthor:

--- a/frontend/src/KindleDetails.jsx
+++ b/frontend/src/KindleDetails.jsx
@@ -27,7 +27,7 @@ function KindleDetails({bookstore}) {
       </div>
       <div className="kindle-details-group">
         <div className="kindle-details-group-title">Regalias</div>
-        <div className="kindle-details-group-value">{formatNumber(bookstore.ganancia)}</div>
+        <div className="kindle-details-group-value">{formatNumber(bookstore.regalias)}</div>
       </div>
     </div>
   )

--- a/frontend/src/Modal.jsx
+++ b/frontend/src/Modal.jsx
@@ -17,6 +17,7 @@ import DeleteTransferModal from './DeleteTransferModal';
 import AddingTransferToAuthorModal from './AddingTransferToAuthorModal';
 import AddingTransferFromAuthorModal from './AddingTransferFromAuthorModal';
 import AddingAuthorModal from './AddingAuthorModal';
+import AddingMultipleAuthorsModal from './AddingMultipleAuthorsModal';
 import EditAuthorModal from './EditAuthorModal';
 import DeleteAuthorModal from './DeleteAuthorModal';
 import AddingBookModal from './AddingBookModal';
@@ -87,6 +88,7 @@ function Modal({
     },
     author: {
       adding: AddingAuthorModal,
+      addingMultiples: AddingMultipleAuthorsModal,
       edit: EditAuthorModal,
       delete: DeleteAuthorModal
     },

--- a/frontend/src/PaymentsList.jsx
+++ b/frontend/src/PaymentsList.jsx
@@ -105,7 +105,7 @@ function PaymentsList() {
         borderRadius: '15px',
         backgroundColor: "#fff",
         position: "fixed",
-        top: "180px",
+        top: "90px",
         left: "10px",
         width: "98.5vw"
       }
@@ -239,7 +239,7 @@ function PaymentsList() {
             Pagados
           </option>
         </select>
-        <div>Añadir un costo addicional solamente se puede hacer con un pago que todavía no esta solicitado</div>
+        {/* <div>Añadir un costo addicional solamente se puede hacer con un pago que todavía no esta solicitado</div> */}
       </div>
       
       {isModalOpen && <Modal modalType={modalType} modalAction={modalAction}

--- a/frontend/src/SalesContent.jsx
+++ b/frontend/src/SalesContent.jsx
@@ -36,7 +36,7 @@ const SalesContent = ({
                   title={`${book.title}: ${book.quantity} libros (${formatNumber(book.value)})`}>
                     <div>
                       <div style={{fontWeight: "bold"}}>{book.title}</div>
-                      <div>{book.quantity} libros - <span>{formatNumber(book.value)})</span></div>
+                      <div>{book.quantity} libros - <span>{formatNumber(book.value)}</span></div>
                     </div>
                 </li>
               ))}

--- a/frontend/src/TableBookstoresRowDetails.jsx
+++ b/frontend/src/TableBookstoresRowDetails.jsx
@@ -54,7 +54,7 @@ function TableBookstoresRowDetails({monthlySalesData}) {
             </div>
             <div className="tbr-name">
               {bookstore.name === "Kindle"
-                ? formatNumber(bookstore.ganancia)
+                ? formatNumber(bookstore.regalias)
                 : formatNumber(bookstore.quantity * bookstore.ganancia)}
             </div>
           </div>

--- a/frontend/src/TableWithDrawers.jsx
+++ b/frontend/src/TableWithDrawers.jsx
@@ -9,6 +9,7 @@ import Modal from "./Modal";
 import Alert from "./Alert";
 import useCheckAdmin from "./customHooks/useCheckAdmin";
 import formatNumber from "./customHooks/formatNumber";
+import { convertDateStringToLocalFormat } from "../../backend/utils";
 
 function TableWithDrawers({
   data,
@@ -54,6 +55,7 @@ function TableWithDrawers({
       return [
         {
           header: "Acciones",
+          size: 50,
           Cell: ({row}) => (
             <div style={{overflow:"visible"}}>
               <TableActions openModal={openModal} row={row} />
@@ -67,6 +69,7 @@ function TableWithDrawers({
         },
         {
           header: "Cantidad",
+          size: 50,
           accessorKey: "quantity"
         },
         {
@@ -75,6 +78,7 @@ function TableWithDrawers({
         },
         {
           header: "Librería",
+          size: 50,
           accessorKey: "inventory.bookstore.name"
         },
         {
@@ -83,13 +87,16 @@ function TableWithDrawers({
         },
         {
           header: "Fecha",
-          accessorKey: "date"
+          Cell: ({row}) => (
+            <div>{convertDateStringToLocalFormat(row.original.date)}</div>
+          )
         },
       ]
     } else if (salesType === "kindle") {
       return [
         {
           header: "Acciones",
+          size: 50,
           Cell: ({row}) => (
             <div style={{overflow:"visible"}}>
               <TableActions openModal={openModal} row={row} />
@@ -112,23 +119,30 @@ function TableWithDrawers({
         },
         {
           header: "Cantidad eBook",
+          size: 50,
           accessorKey: "quantityEbook"
         },
         {
           header: "Cantidad Pod",
+          size: 50,
           accessorKey: "quantityPod"
         },
         {
           header: "Fecha de corte",
-          accessorKey: "dateCut"
+          size: 50,
+          Cell: ({row}) => (
+            <div>{convertDateStringToLocalFormat(row.original.dateCut)}</div>
+          )
         },
         {
           header: "Fecha de pago",
-          accessorKey: "datePay"
+          size: 50,
+          Cell: ({row}) => (
+            <div>{convertDateStringToLocalFormat(row.original.datePay)}</div>
+          )
         },
         {
           header: "Regalías",
-          // accessorKey: "regalias"
           Cell: ({row}) => (
             <div>{formatNumber(row.original.regalias)}</div>
           )
@@ -149,7 +163,7 @@ function TableWithDrawers({
       density: 'compact',
       sorting: [
         {
-          id: 'date',
+          id: 'Fecha',
           asc: true
         }
       ]
@@ -162,7 +176,6 @@ function TableWithDrawers({
       sx: {
         margin: 0,
         marginTop: "0.5rem",
-        // width: "auto",
         height: "auto",
         flex: 1
       }


### PR DESCRIPTION
- Fixed an issue where the KindleSales were not aggregating correctly. 
- Fixed an issue where deleted kindleSales were taken into consideration for the amount of a specific payment. 
- Costs are now tied to books as well as payments. 
- Fixed an issue where adding new costs would not work even if the data passed was valid. 
- Updated the backend endpoint for adding and editing costs to ensure their ties to books. 
- You can now add a cost from the Costos tab. 
- Changed the logic for solicitating payment - it's now only possible 10 days after the start of the next month. 
- Removed the Uso de CFDI in demandPaymentModal. Replaced it with extra info. 
- Adjusted all columns sizes from MaterialReactTables so that the content is entirely checkable without scrolling (mostly). 
- Added an endpoint for adding multiple authors in one go through csv. 
- Added the frontend modal component for adding multiple authors thorugh csv parsing.