### PR TITLE
salesList auto reload and returns smooth display

### DIFF
--- a/frontend/src/AuthorInventory.jsx
+++ b/frontend/src/AuthorInventory.jsx
@@ -38,11 +38,6 @@ function AuthorInventory(){
     setShowTotal(true);
   },[])
 
-
-  useEffect(() => {
-    console.log(legendDisplays)
-  }, [legendDisplays])
-
   async function fetchInventories() {
     try {
       const cachedAuthorInventoriesTotals = sessionStorage.getItem("authorInventoriesTotals");

--- a/frontend/src/DateRange.jsx
+++ b/frontend/src/DateRange.jsx
@@ -14,12 +14,12 @@ function DateRange({
         className="global-input dr-input"
         type="date"
         value={convertISOString(startDate)}
-        onChange={(e) => setStartDate(new Date(e.target.value).toISOString())}></input>
+        onChange={(e) => setStartDate(new Date(e.target.value))}></input>
       <input
         className="global-input dr-input"
         type="date"
         value={convertISOString(endDate)}
-        onChange={(e) => setEndDate(new Date(e.target.value).toISOString())}></input>
+        onChange={(e) => setEndDate(new Date(e.target.value))}></input>
     </div>
   )
 }

--- a/frontend/src/DateRange.jsx
+++ b/frontend/src/DateRange.jsx
@@ -14,12 +14,12 @@ function DateRange({
         className="global-input dr-input"
         type="date"
         value={convertISOString(startDate)}
-        onChange={(e) => setStartDate(new Date(e.target.value))}></input>
+        onChange={(e) => setStartDate(new Date(e.target.value).toISOString())}></input>
       <input
         className="global-input dr-input"
         type="date"
         value={convertISOString(endDate)}
-        onChange={(e) => setEndDate(new Date(e.target.value))}></input>
+        onChange={(e) => setEndDate(new Date(e.target.value).toISOString())}></input>
     </div>
   )
 }

--- a/frontend/src/InventoryGraph.jsx
+++ b/frontend/src/InventoryGraph.jsx
@@ -19,7 +19,7 @@ function InventoryGraph({
   const [max, setMax] = useState(0);
   const [scope, setScope] = useState("book");
   const [isLoading, setLoading] = useState(false);
-
+  const [triggerResize, setTriggerResize] = useState(false);
 
   async function fetchAllAuthorInventories() {
     try {
@@ -218,7 +218,8 @@ function InventoryGraph({
           scope={scope}
           setScope={setScope}
           setSelectedBookId={setSelectedBookId}
-          setLegendDisplays={setLegendDisplays}/>
+          setLegendDisplays={setLegendDisplays}
+          setTriggerResize={setTriggerResize}/>
         <div className="aig-title"><h2>{displayScopeInTitle()}</h2></div>
       </div>
       {isLoading && (
@@ -233,11 +234,15 @@ function InventoryGraph({
           given={legendDisplays['givenToAuthor'] && dataPoint[1].givenToAuthor}
           returns={legendDisplays['returns'] && dataPoint[1].returns}
           current={legendDisplays['current'] && dataPoint[1].current}
-          max={max} />))}
+          max={max} 
+          triggerResize={triggerResize} 
+          setTriggerResize={setTriggerResize}/>))}
       <Legend
         values={legendValues}
         displays={legendDisplays}
-        setDisplays={setLegendDisplays}/>
+        setDisplays={setLegendDisplays}
+        triggerResize={triggerResize}
+        setTriggerResize={setTriggerResize}/>
     </div>
   )
 }

--- a/frontend/src/Legend.jsx
+++ b/frontend/src/Legend.jsx
@@ -1,6 +1,12 @@
 import "./Legend.scss";
 
-function Legend({values, displays, setDisplays}) {
+function Legend({
+  values, 
+  displays, 
+  setDisplays,
+  triggerResize,
+  setTriggerResize
+}) {
   const valuesToDisplay = {
     0: "givenToAuthor",
     1: "sold",
@@ -20,10 +26,14 @@ function Legend({values, displays, setDisplays}) {
             style={displays[valuesToDisplay[index]]
               ? {backgroundColor: `${value[1]}`, border: `1px solid ${value[1]}`}
               : {backgroundColor: "#f8f9fa", border: `1px solid ${value[1]}`}}
-            onClick={() => setDisplays(prev => ({
-              ...prev,
-              [valuesToDisplay[index]]: !prev[valuesToDisplay[index]]
-            }))}>
+            onClick={() => {
+              setDisplays(prev => ({
+                ...prev,
+                [valuesToDisplay[index]]: !prev[valuesToDisplay[index]]
+              }));
+              setTriggerResize(!triggerResize);
+              }
+            }>
           </div>
           <div className="legend-value-name">{value[0]}</div>
         </div>

--- a/frontend/src/OverlappingHorizontalGraphLines.jsx
+++ b/frontend/src/OverlappingHorizontalGraphLines.jsx
@@ -8,7 +8,9 @@ export default function OverlappingHorizontalGraphLines2({
     given,
     current,
     returns,
-    max}) {
+    max,
+    triggerResize,
+  }) {
   const [isTitleTooltipOpen, setTitleTooltipOpen] = useState(false);
   const titleRef = useRef();
   const [isEllipsed, setEllipsed] = useState(false);
@@ -29,7 +31,7 @@ export default function OverlappingHorizontalGraphLines2({
   const actualLinesRef = useRef();
   const numberGivenRef = useRef();
   const numberSoldRef = useRef();
-  const numberReturnsRef = useRef();
+  // const numberReturnsRef = useRef();
   const numberCurrentRef = useRef();
   const currentReturnsRef = useRef();
   const [spanValue, setSpanValue] = useState("incl."); 
@@ -37,7 +39,12 @@ export default function OverlappingHorizontalGraphLines2({
 
   useLayoutEffect(() => {
     calcLengths()
-  }, [sold, given, current, returns, max])
+    if (triggerResize && returns > 0) {
+      displayReturns()
+    } else if (!triggerResize && returns > 0) {
+      returnLengths()
+    }
+  }, [sold, given, current, returns, max, triggerResize])
 
   function calcLengthOfNumbers(key) {
     const possibleValues = {
@@ -116,9 +123,10 @@ export default function OverlappingHorizontalGraphLines2({
   }
 
   function slightlyMove() {
+    if (triggerResize && returns > 0) {return}
+
     // determine which numbers are not being displayed successfully
     const currentNumWidth = currentReturnsRef.current.getBoundingClientRect().width
-    console.log("currentNumWidth", currentNumWidth);
 
     let actualLines = [];
     for (let i = 0; i < Object.entries(lengths).length; i++) {
@@ -148,10 +156,9 @@ export default function OverlappingHorizontalGraphLines2({
           min = actualLines[i][1] - calcLengthOfNumbers(actualLines[i][0]);
         }
         const diff = newLengths[i-1][1] - min
-        console.log("diff", diff);
         if (diff > -4) {
           const potentialLength = actualLines[i][1] + diff
-          const missing = calcLengthOfNumbers(actualLines[i][0]) + (diff / 2)
+          const missing = calcLengthOfNumbers(actualLines[i][0]) + (diff/2)
           if (potentialLength > maxLength) {
             newLengths[actualLines[i-1][0]] -= missing + 8
           } else {
@@ -188,6 +195,7 @@ export default function OverlappingHorizontalGraphLines2({
   } 
 
   function returnLengths() {
+    if (triggerResize && returns > 0) {return}
     setLengths(savedLengths);
   }
 
@@ -210,6 +218,33 @@ export default function OverlappingHorizontalGraphLines2({
   useEffect(() => {
     adjustForReturns()
   }, [scope, title])
+
+  function displayReturns() {
+    const currentNumsWidth = currentReturnsRef.current.getBoundingClientRect().width;
+    const soldWidth = lengths.sold;
+    const currentWidth = lengths.current;
+
+    const minToDisplay = currentWidth - currentNumsWidth;
+    const diff = soldWidth - minToDisplay;
+
+    const spaceRight = currentWidth + diff + 12
+    const newLengths = {
+      given : lengths.given,
+      sold: lengths.sold,
+      returns: lengths.returns,
+      current: lengths.current
+    }
+
+    if (diff > 0) {
+      if (spaceRight > maxLength) {
+        newLengths.sold -= diff + 12
+      } else {
+        newLengths.current += diff + 12
+      }
+    }
+
+    setLengths(newLengths);
+  }
 
   return(
     <div className="ohgl-global">

--- a/frontend/src/SalesListPerMonths.jsx
+++ b/frontend/src/SalesListPerMonths.jsx
@@ -62,10 +62,6 @@ function SalesListPerMonths() {
       console.log(error);
     }
   }
-  
-  useEffect(() => {
-    fetchSalesPerMonths(startDate, endDate);
-  }, [forceRender])
 
   async function refetchAndFilter() {
     let monthData = [];

--- a/frontend/src/ScopeSelector.jsx
+++ b/frontend/src/ScopeSelector.jsx
@@ -3,7 +3,13 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBook, faShop } from '@fortawesome/free-solid-svg-icons'
 import { useState } from "react";
 
-function ScopeSelector({scope, setScope, setSelectedBookId, setLegendDisplays}) {
+function ScopeSelector({
+  scope, 
+  setScope, 
+  setSelectedBookId, 
+  setLegendDisplays,
+  setTriggerResize
+}) {
   const [isBookTooltipOpen, setBookTooltipOpen] = useState(false);
   const [isBookstoreTooltipOpen, setBookstoreTooltipOpen] = useState(false);
 
@@ -31,7 +37,8 @@ function ScopeSelector({scope, setScope, setSelectedBookId, setLegendDisplays}) 
             "sold": true,
             "current": true,
             "returns": false
-          })
+          });
+          setTriggerResize(false)
         }}
         onMouseEnter={() => setBookTooltipOpen(true)}
         onMouseLeave={() => setBookTooltipOpen(false)} />
@@ -48,7 +55,9 @@ function ScopeSelector({scope, setScope, setSelectedBookId, setLegendDisplays}) 
             "sold": true,
             "current": true,
             "returns": false
-          })}}
+          });
+          setTriggerResize(false)
+        }}
         onMouseEnter={() => setBookstoreTooltipOpen(true)}
         onMouseLeave={() => setBookstoreTooltipOpen(false)} />
       {isBookstoreTooltipOpen && (


### PR DESCRIPTION
- Fixed an issue where a duplicate useEffect hook would trigger force reloads of SalesListPerMonth incorrectly
- Added a function to ensure the returns data would display smoothly on legend click.