### PR TITLE
Updating a sale or kindleSale robustness.

### DIFF
--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -14,6 +14,7 @@ import multer from "multer";
 import { validateInput } from "../validations.js";
 import { validateInputs } from "./../utils.js";
 import { createRandomPassword } from "../passwordUtils.js";
+import { version } from "os";
 
 const upload = multer();
 const router = express.Router();
@@ -2241,6 +2242,7 @@ export async function updateSale(req, res) {
     validateInputs(inputs);
 
     const prismaClient = req.prisma || prisma
+    // console.log("db", process.env.DATABASE_URL)
 
     await prismaClient.$transaction(async (tx) => {
       const selectedInventory = await tx.inventory.findUnique({where : {
@@ -2272,9 +2274,15 @@ export async function updateSale(req, res) {
           payments: true
         }
       });
+
       if (previousSale.isDeleted) {
         res.status(400).json({message: "Esta venta ha sido eliminada"})
         return;
+      }
+
+      let previousSalePayments = []
+      for (const payment of previousSale.payments) {
+        previousSalePayments.push({"id": payment.id})
       }
 
       let quantityUpdate = previousSale.quantity - inputs.quantity;
@@ -2319,14 +2327,61 @@ export async function updateSale(req, res) {
             continue;
           }
 
-          // if (existingPayment 
-          //   && (existingPayment.status === "paid" || existingPayment.status === "solicited")) {
-            
-          // }
+          if (existingPayment && !existingPayment.isDeleted && existingPayment.status === "created") {
+            recipientPayments.push({"id": existingPayment.id});
+            continue;
+          }
 
-          recipientPayments.push({"id": existingPayment.id});
+          if (existingPayment 
+            && !existingPayment.isDeleted
+            && (existingPayment.status === "paid" || existingPayment.status === "solicited")) {
+
+            let currentForMonthDate = new Date(existingPayment.forMonth + "-01")
+            let nextPaymentDate = new Date(currentForMonthDate)
+            nextPaymentDate.setMonth(nextPaymentDate.getMonth() +1)
+
+            let nextPayment = await prismaClient.payment.findUnique({where: {
+              userId_forMonth: {
+                userId: user.id,
+                forMonth: getForMonth(nextPaymentDate)
+              }
+            }})
+
+            let paymentEncountered = false;
+            while(nextPayment) {
+              if (nextPayment.isDeleted 
+              || nextPayment.status === "solicited"
+              || nextPayment.status === "paid") {
+                nextPaymentDate.setMonth(nextPaymentDate.getMonth() +1)
+                nextPayment = await prismaClient.payment.findUnique({where: {
+                  userId_forMonth: {
+                    userId: user.id,
+                    forMonth: getForMonth(nextPaymentDate)
+                  }
+                }})
+                continue;
+
+              } else {
+                paymentEncountered = true;
+                recipientPayments.push({"id": nextPayment.id})
+                break;
+              }
+            }
+
+            if (!paymentEncountered) {
+              const newPayment = await prismaClient.payment.create({
+                data: {
+                  userId: user.id,
+                  forMonth: getForMonth(nextPaymentDate)
+                }
+              })
+
+              recipientPayments.push({"id": newPayment.id});
+              continue;
+            }
+          }
         };          
-      } 
+      }
 
       const updatedSale = await tx.sale.update({
         where: {id: inputs.id},
@@ -2335,7 +2390,7 @@ export async function updateSale(req, res) {
           quantity: inputs.quantity,
           date: new Date(inputs.date), 
           payments: {
-            set: recipientPayments
+            set: recipientPayments.length > 0 ? recipientPayments : previousSalePayments
           }
         },
         include: {
@@ -3373,6 +3428,11 @@ export async function updateKindleSale(req, res) {
     })
     if (targetSale.isDeleted) { throw new Error ("deleted kindle sale") }
 
+    let previousSalePayments = []
+    for (const payment of targetSale.payments) {
+      previousSalePayments.push({"id": payment.id})
+    }
+
     let recipientPayments = []
     if (getForMonth(inputs.datePay) !== getForMonth(targetSale.datePay)) {
       for (const user of targetSale.book.users) {
@@ -3392,6 +3452,7 @@ export async function updateKindleSale(req, res) {
               forMonth: getForMonth(inputs.datePay)
             }
           })
+
           recipientPayments.push({"id": createdPayment.id})
           continue;
         }
@@ -3408,7 +3469,58 @@ export async function updateKindleSale(req, res) {
           continue;
         }
 
-        recipientPayments.push({"id": existingPayment.id});
+        if (existingPayment && !existingPayment.isDeleted && existingPayment.status === "created") {
+          recipientPayments.push({"id": existingPayment.id});
+          continue;
+        }
+
+        if (existingPayment 
+        && !existingPayment.isDeleted
+        && (existingPayment.status === "paid" || existingPayment.status === "solicited")) {
+          let currentForMonthDate = new Date(existingPayment.forMonth + "-01")
+          let nextPaymentDate = new Date(currentForMonthDate)
+          nextPaymentDate.setMonth(nextPaymentDate.getMonth() +1)
+
+          let nextPayment = await prismaClient.payment.findUnique({where: {
+            userId_forMonth: {
+              userId: user.id,
+              forMonth: getForMonth(nextPaymentDate)
+            }
+          }})
+
+          let paymentEncountered = false;
+          while(nextPayment) {
+            if (nextPayment.isDeleted 
+            || nextPayment.status === "solicited"
+            || nextPayment.status === "paid") {
+              nextPaymentDate.setMonth(nextPaymentDate.getMonth() +1)
+              nextPayment = await prismaClient.payment.findUnique({where: {
+                userId_forMonth: {
+                  userId: user.id,
+                  forMonth: getForMonth(nextPaymentDate)
+                }
+              }})
+              continue;
+
+            } else {
+              paymentEncountered = true;
+              recipientPayments.push({"id": nextPayment.id})
+              break;
+            }
+          }
+
+          if (!paymentEncountered) {
+            const newPayment = await prismaClient.payment.create({
+              data: {
+                userId: user.id,
+                forMonth: getForMonth(nextPaymentDate)
+              }
+            })
+
+            recipientPayments.push({"id": newPayment.id});
+            continue;
+          }
+        }
       };          
     } 
 
@@ -3423,7 +3535,7 @@ export async function updateKindleSale(req, res) {
         datePay: inputs.datePay,
         regalias: inputs.regalias,
         payments: {
-          set: recipientPayments
+          set: recipientPayments.length > 0 ? recipientPayments : previousSalePayments 
         }
       }
     })

--- a/backend/tests/admin/kindleSales.update.test.js
+++ b/backend/tests/admin/kindleSales.update.test.js
@@ -86,6 +86,7 @@ describe(`updating Kindle sale with valid parameters`, async() => {
 })
 
 
+
 describe(`updating a kindleSale date for a book with multiple authors`, async() => {
   let mockReq, mockRes;
   let newAuthor, newAuthor2, newAuthor3, newAuthor4;
@@ -107,8 +108,8 @@ describe(`updating a kindleSale date for a book with multiple authors`, async() 
     oldPayment = await createPayment(prisma, newAuthor.id, "2025-10")
     oldPayment2 = await createPayment(prisma, newAuthor2.id, "2025-10")
     oldPayment3 = await createPayment(prisma, newAuthor3.id, "2025-10", {isDeleted: true}) 
-    newKindleSale = await createKindleSale(prisma, newBook.id, [newPayment.id, newPayment2.id], {quantityEbook: 10, quantityPod: 10, datePay: new Date("2025-06-02"), regalias: 100})
-    deletedKindleSale = await createKindleSale(prisma, newBook.id, [newPayment.id, newPayment2.id], {quantityEbook: 10, quantityPod: 10, datePay: new Date("2025-06-02"), regalias: 100, isDeleted: true})
+    newKindleSale = await createKindleSale(prisma, newBook.id, [newPayment.id, newPayment2.id, newPayment3.id, newPayment4.id], {quantityEbook: 10, quantityPod: 10, datePay: new Date("2025-11-02"), regalias: 100})
+    deletedKindleSale = await createKindleSale(prisma, newBook.id, [newPayment.id, newPayment2.id], {quantityEbook: 10, quantityPod: 10, datePay: new Date("2025-11-02"), regalias: 100, isDeleted: true})
 
 
     mockReq = {
@@ -149,6 +150,7 @@ describe(`updating a kindleSale date for a book with multiple authors`, async() 
       try {
         expect(payment.forMonth).toBe("2025-10");
       } catch(error) {
+        
         console.log(`there was an error with payment ${payment.id}`)
         throw error
       }
@@ -220,13 +222,6 @@ describe('updating a deleted Kindle sale', async() => {
   })
 
   afterAll(async() => {
-    // await deleteFromDB(prisma, newKindleSale, "kindleSale")
-    // await deleteFromDB(prisma, deletedKindleSale, "kindleSale")
-    // await deleteFromDB(prisma, newPayment2, "payment")
-    // await deleteFromDB(prisma, newPayment, "payment")
-    // await deleteFromDB(prisma, newBook, "book")
-    // await deleteFromDB(prisma, newAuthor, "author")
-    // await deleteFromDB(prisma, newAuthor2, "author")
     mute.mockRestore()
   })
 
@@ -240,5 +235,76 @@ describe('updating a deleted Kindle sale', async() => {
     expect(updatedKindleSale.quantityEbook).toBe(10),
     expect(updatedKindleSale.quantityPod).toBe(10),
     expect(updatedKindleSale.regalias).toBe(100)
+  })
+})
+
+
+
+describe(`updating the date of a kindleSale but the payment for that date is unavailable 
+(deleted, paid or solicited)`, async() => {
+  let mockReq, mockRes, res;
+  let author1, author2, author3;
+  let book;
+  let bookstore;
+  let inventory;
+  let payment1, payment2, payment3, payment4, payment5, payment6, payment7, payment8;
+  let kindleSale;
+
+  beforeAll(async() => {
+    author1 = await createAuthor(prisma);
+    author2 = await createAuthor(prisma);
+    author3 = await createAuthor(prisma);
+    book = await createBook(prisma, [author1.id, author2.id, author3.id]);
+    bookstore = await createBookstore(prisma);
+    inventory = await createInventory(prisma, book.id, bookstore.id);
+    payment1 = await createPayment(prisma, author1.id, "2025-06", {status: "paid"})
+    payment2 = await createPayment(prisma, author1.id, "2025-07", {status: "solicited"})
+    payment3 = await createPayment(prisma, author1.id, "2025-08", {status: "created"})
+    payment4 = await createPayment(prisma, author2.id, "2025-06", {status: "paid"})
+    payment5 = await createPayment(prisma, author2.id, "2025-07", {status: "paid"})
+    payment6 = await createPayment(prisma, author2.id, "2025-08", {status: "created"})
+    payment7 = await createPayment(prisma, author3.id, "2025-06", {isDeleted: true})
+    payment8 = await createPayment(prisma, author3.id, "2025-07", {status: "solicited"})
+    kindleSale = await createKindleSale(prisma, book.id, [payment2.id, payment5.id, payment8.id], {datePay: new Date("2025-07-04")})
+
+    mockReq = {
+      params: {
+        id: kindleSale.id
+      },
+      body: {
+        quantityEbook: 10,
+        quantityPod: 10,
+        dateCut: new Date("2025-04-04"),
+        datePay: new Date("2025-06-04"),
+        regalias: 100
+      },
+      prisma: prisma
+    }
+
+    mockRes = {
+      json: vi.fn(),
+      status: vi.fn().mockReturnThis()
+    }
+  })
+
+  it(`should find the nearest available date 
+  and reassign the kindle sale to this payment`, async() => {
+    await updateKindleSale(mockReq, mockRes);
+    res = await prisma.kindleSale.findUnique({where: {id: kindleSale.id}, include: {payments: true}})
+    expect(res.payments.length).toBe(3)
+  })
+
+  it(`should reassign the sale to the closest created payment status for an author`, async() => {
+    const author1payment = res.payments.find(payment => payment.userId === author1.id)
+    expect(author1payment.id).toBe(payment3.id)
+
+    const author2payment = res.payments.find(payment => payment.userId === author2.id)
+    expect(author2payment.id).toBe(payment6.id)
+  })
+
+  it(`should recreate the payment if the sale is deleted or doesn't exist`, async() => {
+    const author3payment = res.payments.find(payment => payment.userId === author3.id)
+    expect(author3payment.forMonth).toBe("2025-06")
+    expect(author3payment.id).not.toBe(payment7.id)
   })
 })

--- a/backend/tests/admin/sales.update.test.js
+++ b/backend/tests/admin/sales.update.test.js
@@ -1,5 +1,4 @@
 import { describe, expect, vi, it, beforeAll, afterAll } from "vitest";
-import { getForMonth } from "../../utils.js";
 import { updateSale } from "../../routes/adminRoutes.js";
 import {
   createCategory,
@@ -38,132 +37,34 @@ afterAll(async() => {
 
 
 
-async function seed() {
-  let newAuthor = await createAuthor(prisma);
-
-  let newBook = await createBook(prisma, [newAuthor.id]);
-  let newBook2 = await createBook(prisma, [newAuthor.id]);
-  let newBook3 = await createBook(prisma, [newAuthor.id]);
-  let newBook4 = await createBook(prisma, [newAuthor.id]);
-  let newBook5 = await createBook(prisma, [newAuthor.id]);
-
-  let deletedBook = await createBook(prisma, [newAuthor.id], {isDeleted: true});
-
-  let newImpression = await createImpression(prisma, newBook.id, {quantity: 1000, note: "this is the note", date: new Date("2025-10-29")});
-  let newImpression2 = await createImpression(prisma, newBook.id, {quantity: 1000});
-  let newImpression3 = await createImpression(prisma, newBook.id, {quantity: 1000});
-  let deletedImpression = await createImpression(prisma, newBook.id, {quantity: 100, isDeleted: true});
-
-  let newBookstore = await createBookstore(prisma);
-  let newBookstore2 = await createBookstore(prisma);
-  let newBookstore3 = await createBookstore(prisma);
-  let newBookstore4 = await createBookstore(prisma);
-  let deletedBookstore = await createBookstore(prisma, {isDeleted: true});
-
-  let deletedInventory = await createInventory(prisma, newBook2.id, newBookstore.id, {initial: 1000, current: 1000, isDeleted: true});
-  let newInventory = await createInventory(prisma, newBook.id, newBookstore.id, {initial: 3000, current: 3000, isDeleted: false, returns: 0, givenToAuthor: 0});
-  let newInventory2 = await createInventory(prisma, newBook.id, newBookstore2.id, {initial: 3000, current: 3000, isDeleted: false, returns: 10, givenToAuthor:  10});
-  let newInventory3 = await createInventory(prisma, newBook.id, newBookstore3.id, {initial: 3000, current: 3000, isDeleted: false, returns: 10, givenToAuthor:  10});
-  let newInventory4 = await createInventory(prisma, newBook.id, newBookstore4.id, {initial: 3000, current: 3000, isDeleted: true, returns: 0, givenToAuthor: 0});
-  let newInventory5 = await createInventory(prisma, newBook3.id, newBookstore.id, {initial: 3000, current: 3000, isDeleted: false, returns: 10, givenToAuthor:  10});
-  let newInventory6 = await createInventory(prisma, newBook4.id, newBookstore.id, {initial: 3000, current: 3000, isDeleted: false, returns: 10, givenToAuthor:  10});
-  let newInventory7 = await createInventory(prisma, newBook5.id, newBookstore.id, {initial: 3000, current: 3000, isDeleted: true, returns: 10, givenToAuthor: 10});
-  let newPayment = await createPayment(prisma, newAuthor.id, getForMonth(new Date("2025-11-02")));
-  let previousPayment = await createPayment(prisma, newAuthor.id, getForMonth(new Date("2025-09-02")));
-  let oldPayment = await createPayment(prisma, newAuthor.id, getForMonth(new Date("2024-01-01")));
-
-  let deletedSale = await createSale(prisma, newInventory.id, [newPayment.id], {quantity: 100, isDeleted: true});
-  let newSale1 = await createSale(prisma, newInventory.id, [newPayment.id], {quantity: 100});
-  let newSale2 = await createSale(prisma, newInventory.id, [newPayment.id], {quantity: 100});
-  let newSale3 = await createSale(prisma, newInventory.id, [newPayment.id], {quantity: 100, isDeleted: true});
-  let newSale4 = await createSale(prisma, newInventory2.id, [newPayment.id], {quantity: 100});
-  let oldSale = await createSale(prisma, newInventory.id, [newPayment.id], {quantity: 100, date: new Date("2024-01-01")});
-
-  const testDBObjects = {
-    newAuthor:       { type: "author", data: newAuthor },
-
-    newBook:         { type: "book", data: newBook },
-    newBook2:        { type: "book", data: newBook2 },
-    newBook3:        { type: "book", data: newBook3 },
-    newBook4:        { type: "book", data: newBook4 },
-    newBook5:        { type: "book", data: newBook5 },
-
-    deletedBook:     { type: "book", data: deletedBook },
-
-    newImpression:   { type: "impression", data: newImpression },
-    newImpression2:  { type: "impression", data: newImpression2 },
-    newImpression3:  { type: "impression", data: newImpression3 },
-    deletedImpression:{ type: "impression", data: deletedImpression },
-
-    newBookstore:    { type: "bookstore", data: newBookstore },
-    newBookstore2:   { type: "bookstore", data: newBookstore2 },
-    newBookstore3:   { type: "bookstore", data: newBookstore3 },
-    newBookstore4:   { type: "bookstore", data: newBookstore4 },
-    deletedBookstore:{ type: "bookstore", data: deletedBookstore },
-
-    deletedInventory:{ type: "inventory", data: deletedInventory },
-    newInventory:    { type: "inventory", data: newInventory },
-    newInventory2:   { type: "inventory", data: newInventory2 },
-    newInventory3:   { type: "inventory", data: newInventory3 },
-    newInventory4:   { type: "inventory", data: newInventory4 },
-    newInventory5:   { type: "inventory", data: newInventory5 },
-    newInventory6:   { type: "inventory", data: newInventory6 },
-    newInventory7:   { type: "inventory", data: newInventory7 },
-
-    newPayment:      { type: "payment", data: newPayment },
-    previousPayment: { type: "payment", data: previousPayment},
-    oldPayment:      { type: "payment", data: oldPayment },
- 
-    deletedSale:     { type: "sale", data: deletedSale },
-    newSale1:        { type: "sale", data: newSale1 },
-    newSale2:        { type: "sale", data: newSale2 },
-    newSale3:        { type: "sale", data: newSale3 },
-    newSale4:        { type: "sale", data: newSale4 },
-    oldSale:         { type: "sale", data: oldSale },
-  };
-  return testDBObjects
-}
-
-async function reap(testDBObjects) {
-  const deletionList = [
-    "oldSale", "newSale1", "newSale2", "newSale3", "newSale4", "deletedSale",
-    "oldPayment", "previousPayment", "newPayment", "deletedPayment",
-    'newInventory8', "newInventory7", "newInventory6", "newInventory5", "newInventory4",
-    "newInventory3", "newInventory2", "newInventory", "deletedInventory",
-    "deletedBookstore", "newBookstore4", "newBookstore3", "newBookstore2",
-    "newBookstore",
-    "deletedImpression", "newImpression3", "newImpression2", "newImpression",
-    "deletedBook", "newBook6", "newBook5", "newBook4", "newBook3", "newBook2", "newBook",
-    "newAuthor2", "newAuthor", 
-  ];
-  for (const item of deletionList) {
-    const obj = testDBObjects[item];
-    if (!obj) continue;
-    await deleteFromDB(prisma, obj.data, obj.type);
-    // console.log(`deleted ${obj.type}`);
-  }
-}
-
-
-
 ///UPDATING
 describe(`updating a sale with valid parameters`, async() => {
-  let testDBObjects;
   let mockReq, mockRes;
   let updatedSale, updatedInventory;
+  let author;
+  let book;
+  let bookstore;
+  let inventory;
+  let payment;
+  let sale;
 
   beforeAll(async() => {
-    testDBObjects = await seed();
+    author = await createAuthor(prisma);
+    book = await createBook(prisma, [author.id]);
+    bookstore = await createBookstore(prisma);
+    inventory = await createInventory(prisma, book.id, bookstore.id, {initial: 3000, current: 3000});
+    payment = await createPayment(prisma, author.id, "2025-11");
+    sale = await createSale(prisma, inventory.id, [payment.id], {quantity: 100})
 
     mockReq = {
       params: {
-        "id": testDBObjects.newSale1.data.id
+        "id": sale.id
       },
       body: {
-        "book": testDBObjects.newBook.data.id,
-        "bookstore": testDBObjects.newBookstore.data.id,
-        "quantity": 20,
-        "date": new Date("2025-09-04"),
+        book: book.id,
+        bookstore: bookstore.id,
+        quantity: 20,
+        date: new Date("2025-09-04")
       },
       prisma: prisma
     }
@@ -174,21 +75,15 @@ describe(`updating a sale with valid parameters`, async() => {
     }
   })
 
-  afterAll(async() => {
-    // await deleteFromDB(prisma, updatedSale, "sale");
-    // await deleteFromDB(prisma, updatedInventory, "inventory");
-    await reap(testDBObjects);
-  })
-
   it(`should return a status 200`, async() => {
     await updateSale(mockReq, mockRes);
     expect(mockRes.status).toHaveBeenCalledWith(200);
   })
 
   it(`should update the sale with the correct data`, async() => {
-    updatedSale = await prisma.sale.findUnique({where: {id: testDBObjects.newSale1.data.id}, include: {payments: true}});
-    updatedInventory = await prisma.inventory.findUnique({where: {id: testDBObjects.newInventory.data.id}})
-    expect(updatedSale.id).toBe(testDBObjects.newSale1.data.id);
+    updatedSale = await prisma.sale.findUnique({where: {id: sale.id}, include: {payments: true}});
+    updatedInventory = await prisma.inventory.findUnique({where: {id: inventory.id}})
+    expect(updatedSale.id).toBe(sale.id);
     expect(updatedSale.inventoryId).toBe(updatedInventory.id);
     expect(updatedSale.quantity).toBe(20);
     expect(updatedSale.date).toStrictEqual(new Date("2025-09-04"));
@@ -209,6 +104,8 @@ describe(`updating a sale with valid parameters`, async() => {
     }
   })
 })
+
+
 
 describe(`updating the date of a valid sale for a book with multiple authors`, async() => {
   let mockReq, mockRes;
@@ -255,25 +152,6 @@ describe(`updating the date of a valid sale for a book with multiple authors`, a
       json: vi.fn(),
       status: vi.fn().mockReturnThis()
     }
-  })
-
-  afterAll(async() => {
-    await deleteFromDB(prisma, sale1, "sale");
-    await deleteFromDB(prisma, oldPayment1, "payment");
-    await deleteFromDB(prisma, oldPayment2, "payment");
-    await deleteFromDB(prisma, oldPayment3, "payment");
-    await deleteFromDB(prisma, oldPayment4, "payment");
-    await deleteFromDB(prisma, newPayment1, "payment");
-    await deleteFromDB(prisma, newPayment2, "payment");
-    await deleteFromDB(prisma, recreatedPayment, "payment");
-    await deleteFromDB(prisma, createdPayment, "payment");
-    await deleteFromDB(prisma, inventory1, "inventory");
-    await deleteFromDB(prisma, bookstore1, "bookstore");
-    await deleteFromDB(prisma, book1, "book");
-    await deleteFromDB(prisma, author1, "author");
-    await deleteFromDB(prisma, author2, "author");
-    await deleteFromDB(prisma, author3, "author");
-    await deleteFromDB(prisma, author4, "author");
   })
 
   it(`should return a status 200`, async() => {
@@ -333,24 +211,29 @@ describe(`updating the date of a valid sale for a book with multiple authors`, a
 })
 
 
+
 describe(`updating a sale with a larger quantity than what's remaining`, async() => {
-  let testDBObjects;
   let mockReq, mockRes;
   let newSale100, newInventory100, newBookstore100;
   let updatedSale, updatedInventory;
+  let author;
+  let book;
+  let payment;
 
   beforeAll(async() => {
-    testDBObjects = await seed();
+    author = await createAuthor(prisma);
+    book = await createBook(prisma, [author.id]);
+    payment = await createPayment(prisma, author.id, "2025-11");
     newBookstore100 = await createBookstore(prisma);
-    newInventory100 = await createInventory(prisma, testDBObjects.newBook.data.id, newBookstore100.id , {initial: 3000, current: 100})
-    newSale100 = await createSale(prisma, newInventory100.id, [testDBObjects.newPayment.data.id], {quantity: 100});
+    newInventory100 = await createInventory(prisma, book.id, newBookstore100.id , {initial: 3000, current: 100})
+    newSale100 = await createSale(prisma, newInventory100.id, [payment.id], {quantity: 100});
 
     mockReq = {
       params: {
-        "id": testDBObjects.newSale1.data.id
+        "id": newSale100.id
       },
       body: {
-        "book": testDBObjects.newBook.data.id,
+        "book": book.id,
         "bookstore": newBookstore100.id,
         "quantity": 500,
         "date": new Date(),
@@ -364,45 +247,43 @@ describe(`updating a sale with a larger quantity than what's remaining`, async()
     }
   })
 
-  afterAll(async() => {
-    await deleteFromDB(prisma, newSale100, "sale");
-    await deleteFromDB(prisma, newInventory100, "inventory");
-    await deleteFromDB(prisma, newBookstore100, "bookstore")
-    await reap(testDBObjects);
-  })
-
   it("should return a 400", async() => {
     await updateSale(mockReq, mockRes);
     expect(mockRes.status).toHaveBeenCalledWith(400)
   })
 
   it(`shouldn't let you update the sale if the new quantity is higher than available in inventory`, async() => {
-    updatedSale = await prisma.sale.findUnique({where: {id: testDBObjects.newSale1.data.id}})
+    updatedSale = await prisma.sale.findUnique({where: {id: newSale100.id}})
     updatedInventory = await prisma.inventory.findUnique({where: {id: newInventory100.id}})
     expect(updatedSale.quantity).toBe(100);
     expect(updatedInventory.current).toBe(100);
   })
 })
+
 
 
 describe("updating a sale tied to a deleted inventory", async() => {
-  let testDBObjects;
   let mockReq, mockRes, mute;
   let newSale100, newInventory100, newBookstore100;
   let updatedSale, updatedInventory;
+  let author;
+  let book;
+  let payment;
 
   beforeAll(async() => {
-    testDBObjects = await seed();
+    author = await createAuthor(prisma);
+    book = await createBook(prisma, [author.id]);
+    payment = await createPayment(prisma, author.id, "2025-11")
     newBookstore100 = await createBookstore(prisma);
-    newInventory100 = await createInventory(prisma, testDBObjects.newBook.data.id, newBookstore100.id, {initial: 3000, current: 100, isDeleted: true})
-    newSale100 = await createSale(prisma, newInventory100.id, [testDBObjects.newPayment.data.id], {quantity: 100});
+    newInventory100 = await createInventory(prisma, book.id, newBookstore100.id, {initial: 3000, current: 100, isDeleted: true})
+    newSale100 = await createSale(prisma, newInventory100.id, [payment.id], {quantity: 100});
 
     mockReq = {
       params: {
-        "id": testDBObjects.newSale1.data.id
+        "id": newSale100.id
       },
       body: {
-        "book": testDBObjects.newBook.data.id,
+        "book": book.id,
         "bookstore": newBookstore100.id,
         "quantity": 150,
         "date": new Date(),
@@ -419,10 +300,6 @@ describe("updating a sale tied to a deleted inventory", async() => {
   })
 
   afterAll(async() => {
-    await deleteFromDB(prisma, newSale100, "sale");
-    await deleteFromDB(prisma, newInventory100, "inventory");
-    await deleteFromDB(prisma, newBookstore100, "bookstore")
-    await reap(testDBObjects);
     mute.mockRestore()
   })
 
@@ -432,7 +309,7 @@ describe("updating a sale tied to a deleted inventory", async() => {
   })
 
   it("shouldn't let you update the sale and inventory", async() => {
-    updatedSale = await prisma.sale.findUnique({where: {id: testDBObjects.newSale1.data.id}})
+    updatedSale = await prisma.sale.findUnique({where: {id: newSale100.id}})
     updatedInventory = await prisma.inventory.findUnique({where: {id: newInventory100.id}})
     expect(updatedSale.quantity).toBe(100);
     expect(updatedInventory.current).toBe(100);
@@ -440,24 +317,29 @@ describe("updating a sale tied to a deleted inventory", async() => {
 })
 
 
+
 describe(`updating a deleted sale`, async() => {
-  let testDBObjects;
   let mockReq, mockRes, mute;
   let newSale100, newInventory100, newBookstore100;
   let updatedSale, updatedInventory;
+  let author;
+  let book;
+  let payment;
 
   beforeAll(async() => {
-    testDBObjects = await seed();
+    author = await createAuthor(prisma);
+    book = await createBook(prisma, [author.id]);
+    payment = await createPayment(prisma, author.id, "2025-11")
     newBookstore100 = await createBookstore(prisma);
-    newInventory100 = await createInventory(prisma, testDBObjects.newBook.data.id, newBookstore100.id, {initial: 3000, current: 100, isDeleted: true})
-    newSale100 = await createSale(prisma, newInventory100.id, [testDBObjects.newPayment.data.id], {quantity: 100, isDeleted: true});
+    newInventory100 = await createInventory(prisma, book.id, newBookstore100.id, {initial: 3000, current: 100, isDeleted: true})
+    newSale100 = await createSale(prisma, newInventory100.id, [payment.id], {quantity: 100, isDeleted: true});
 
     mockReq = {
       params: {
-        "id": testDBObjects.newSale1.data.id
+        "id": newSale100.id
       },
       body: {
-        "book": testDBObjects.newBook.data.id,
+        "book": book.id,
         "bookstore": newBookstore100.id,
         "quantity": 150,
         "date": new Date(),
@@ -474,10 +356,6 @@ describe(`updating a deleted sale`, async() => {
   })
 
   afterAll(async() => {
-    await deleteFromDB(prisma, newSale100, "sale");
-    await deleteFromDB(prisma, newInventory100, "inventory");
-    await deleteFromDB(prisma, newBookstore100, "bookstore")
-    await reap(testDBObjects);
     mute.mockRestore()
   })
 
@@ -487,9 +365,185 @@ describe(`updating a deleted sale`, async() => {
   })
 
   it("shouldn't let you update the sale and inventory", async() => {
-    updatedSale = await prisma.sale.findUnique({where: {id: testDBObjects.newSale1.data.id}})
+    updatedSale = await prisma.sale.findUnique({where: {id: newSale100.id}})
     updatedInventory = await prisma.inventory.findUnique({where: {id: newInventory100.id}})
     expect(updatedSale.quantity).toBe(100);
     expect(updatedInventory.current).toBe(100);
+  })
+})
+
+
+
+describe(`updating the date of a sale but the corresponding payment 
+is either paid or solicited`, async() => {
+  let mockReq, mockRes;
+  let author;
+  let book;
+  let bookstore;
+  let inventory;
+  let payment1, payment2, payment3, payment4;
+  let sale;
+
+  beforeAll(async() => {
+    author = await createAuthor(prisma)
+    book = await createBook(prisma, [author.id])
+    bookstore = await createBookstore(prisma)
+    inventory = await createInventory(prisma, book.id, bookstore.id)
+    payment1 = await createPayment(prisma, author.id, "2025-06", {status: "paid"})
+    payment2 = await createPayment(prisma, author.id, "2025-07", {status: "solicited"})
+    payment3 = await createPayment(prisma, author.id, "2025-08", {status: "solicited"})
+    payment4 = await createPayment(prisma, author.id, "2025-09", {status: "created"})
+    sale = await createSale(prisma, inventory.id, [payment2.id], {date: new Date("2025-07-20")})
+
+    mockReq = {
+      params: {
+        id: sale.id
+      }, 
+      body: {
+        book: book.id,
+        bookstore: bookstore.id,
+        quantity: 10,
+        date: new Date("2025-06-20")
+      },
+      prisma: prisma
+    }
+
+    mockRes = {
+      json: vi.fn(),
+      status: vi.fn().mockReturnThis()
+    }
+  })
+
+  it(`should reassign the date to the nearest available payment (payment4)`, async() => {
+    await updateSale(mockReq, mockRes);
+    const reassignedSale = await prisma.sale.findUnique({where: {id: sale.id}, include: {payments: true}})
+    expect(reassignedSale.date).toEqual(new Date("2025-06-20"))
+    expect(reassignedSale.payments.length).toBe(1)
+    expect(reassignedSale.payments[0].id).toBe(payment4.id)
+  })
+})
+
+
+
+describe(`updating the date of a multi-payment sale but the corresponding payments 
+are either paid or solicited`, async() => {
+  let mockReq, mockRes;
+  let author1, author2;
+  let book;
+  let bookstore;
+  let inventory;
+  let payment1, payment2, payment3, payment4, payment5, payment6, payment7;
+  let sale;
+
+  beforeAll(async() => {
+    author1 = await createAuthor(prisma)
+    author2 = await createAuthor(prisma)
+    book = await createBook(prisma, [author1.id, author2.id])
+    bookstore = await createBookstore(prisma)
+    inventory = await createInventory(prisma, book.id, bookstore.id)
+    payment1 = await createPayment(prisma, author1.id, "2025-06", {status: "paid"})
+    payment2 = await createPayment(prisma, author1.id, "2025-07", {status: "solicited"})
+    payment3 = await createPayment(prisma, author1.id, "2025-08", {status: "solicited"})
+    payment4 = await createPayment(prisma, author1.id, "2025-09", {status: "created"})
+    payment5 = await createPayment(prisma, author2.id, "2025-06", {status: "paid"})
+    payment6 = await createPayment(prisma, author2.id, "2025-07", {status: "solicited"})
+    payment7 = await createPayment(prisma, author2.id, "2025-08", {status: "created"})
+    sale = await createSale(prisma, inventory.id, [payment2.id], {date: new Date("2025-07-20")})
+
+    mockReq = {
+      params: {
+        id: sale.id
+      }, 
+      body: {
+        book: book.id,
+        bookstore: bookstore.id,
+        quantity: 10,
+        date: new Date("2025-06-20")
+      },
+      prisma: prisma
+    }
+
+    mockRes = {
+      json: vi.fn(),
+      status: vi.fn().mockReturnThis()
+    }
+  })
+
+  it(`should reassign the date to the nearest available payment for each author`, async() => {
+    await updateSale(mockReq, mockRes);
+    const reassignedSale = await prisma.sale.findUnique({where: {id: sale.id}, include: {payments: true}})
+    expect(reassignedSale.date).toEqual(new Date("2025-06-20"))
+    expect(reassignedSale.payments.length).toBe(2)
+    
+    let reassignedPayments = []
+    for (const payment of reassignedSale.payments) {
+      reassignedPayments.push(payment.id)
+    }
+    expect(reassignedPayments).toContain(payment4.id)
+    expect(reassignedPayments).toContain(payment7.id)
+  })
+})
+
+
+
+describe(`updating the date of a multi-payment sale but the reassignable payments
+are all paid or solicited`, async() => {
+  let mockReq, mockRes;
+  let author1, author2;
+  let book;
+  let bookstore;
+  let inventory;
+  let payment1, payment2, payment3, payment5, payment6;
+  let sale;
+
+  beforeAll(async() => {
+    author1 = await createAuthor(prisma)
+    author2 = await createAuthor(prisma)
+    book = await createBook(prisma, [author1.id, author2.id])
+    bookstore = await createBookstore(prisma)
+    inventory = await createInventory(prisma, book.id, bookstore.id)
+    payment1 = await createPayment(prisma, author1.id, "2025-06", {status: "paid"})
+    payment2 = await createPayment(prisma, author1.id, "2025-07", {status: "solicited"})
+    payment3 = await createPayment(prisma, author1.id, "2025-08", {status: "solicited"})
+    payment5 = await createPayment(prisma, author2.id, "2025-06", {status: "paid"})
+    payment6 = await createPayment(prisma, author2.id, "2025-07", {status: "solicited"})
+    sale = await createSale(prisma, inventory.id, [payment2.id], {date: new Date("2025-07-20")})
+
+    mockReq = {
+      params: {
+        id: sale.id
+      }, 
+      body: {
+        book: book.id,
+        bookstore: bookstore.id,
+        quantity: 10,
+        date: new Date("2025-06-20")
+      },
+      prisma: prisma
+    }
+
+    mockRes = {
+      json: vi.fn(),
+      status: vi.fn().mockReturnThis()
+    }
+  })
+
+  it(`should create a new payment at the nearest available date in the future`, async() => {
+    await updateSale(mockReq, mockRes);
+    const reassignedSale = await prisma.sale.findUnique({where: {id: sale.id}, include: {payments: true}})
+    expect(reassignedSale.date).toEqual(new Date("2025-06-20"))
+    expect(reassignedSale.payments.length).toBe(2)
+    
+    const author1Payment = reassignedSale.payments.find(payment => 
+      payment.userId === author1.id
+      && payment.forMonth === "2025-09" 
+      && payment.status === "created")
+    expect(author1Payment).toBeTruthy();
+
+    const author2Payment = reassignedSale.payments.find(payment => 
+      payment.userId === author2.id
+      && payment.forMonth === "2025-08" 
+      && payment.status === "created")
+    expect(author2Payment).toBeTruthy();
   })
 })


### PR DESCRIPTION
- Modified the backend route for updating sales or kindleSales date. 
- It now correctly reassigns the payment it's tied to. 
- It finds another one if the payment is already paid or solicited and creates a new one if the payment is deleted or doesn't exit.