### PR TITLE
feat(admin): ver el desglose del autor desde la pantalla de Pagos

### DIFF
--- a/backend/routes/author/commissions/getAuthorPayments.js
+++ b/backend/routes/author/commissions/getAuthorPayments.js
@@ -4,6 +4,7 @@ import {
   calculateAuthorRevenue,
   generateMonthKeysForRange,
 } from "../../../utils.js"
+import { resolveAuthorId } from "../resolveAuthorId.js";
 const router = express.Router();
 
 export async function getAuthorPayments (req, res) {
@@ -11,6 +12,8 @@ export async function getAuthorPayments (req, res) {
     if (!req.session.user_id) {
       return res.status(401).json({message: "Unauthorized"})
     }
+
+    const authorId = await resolveAuthorId(req);
 
     const prismaClient = req.prisma || prisma
 
@@ -23,7 +26,7 @@ export async function getAuthorPayments (req, res) {
     const allPayments = await prismaClient.payment.findMany({
       where: {
         isDeleted: false,
-        userId: req.session.user_id,
+        userId: authorId,
         createdAt: {
           gt: ltm
         }

--- a/backend/routes/author/commissions/getMonthlySalesByPayment.js
+++ b/backend/routes/author/commissions/getMonthlySalesByPayment.js
@@ -5,6 +5,7 @@ import {
   calculateAuthorRevenue,
   generateMonthKeysForRange,
 } from "../../../utils.js"
+import { resolveAuthorId } from "../resolveAuthorId.js";
 const router = express.Router();
 
 export async function getMonthlySalesByPayments (req, res) {
@@ -12,6 +13,8 @@ export async function getMonthlySalesByPayments (req, res) {
     if (!req.session.user_id) {
       return res.status(401).json({message: "Unauthorized"})
     }
+
+    const authorId = await resolveAuthorId(req);
 
     const prismaClient = req.prisma || prisma
 
@@ -22,7 +25,7 @@ export async function getMonthlySalesByPayments (req, res) {
     // Get all existing payments and tied sales for that author
     const allAuthorPayments = await prismaClient.payment.findMany({
       where: {
-        userId: req.session.user_id,
+        userId: authorId,
         createdAt: {
           gte: ltm
         }

--- a/backend/routes/author/inventories/getAuthorInventories.js
+++ b/backend/routes/author/inventories/getAuthorInventories.js
@@ -1,9 +1,10 @@
 import express from "express";
 import { prisma } from "../../../prisma/client.js";
-import { 
+import {
   getWasInventoryForThisBook,
   getOtherInventoryForThisBook,
 } from "../../admin/inventories/getBookInventories.js";
+import { resolveAuthorId } from "../resolveAuthorId.js";
 const router = express.Router();
 
 export async function getAuthorInventories (req, res) {
@@ -13,12 +14,14 @@ export async function getAuthorInventories (req, res) {
       return res.status(401).json({ message: "Unauthorized" });
     }
 
+    const authorId = await resolveAuthorId(req);
+
     const prismaClient = req.prisma || prisma
 
     // Fetch all necessary data
     const data = await prismaClient.user.findUnique({
       where: {
-        id: req.session.user_id
+        id: authorId
       },
       select: {
         first_name: true,

--- a/backend/routes/author/inventories/getCompleteInventory.js
+++ b/backend/routes/author/inventories/getCompleteInventory.js
@@ -4,6 +4,7 @@ import {
   getOtherInventory,
   getWasInventory
 } from "../../admin/inventories/inventoryHelpers.js"
+import { resolveAuthorId } from "../resolveAuthorId.js";
 const router = express.Router();
 
 export async function getCompleteInventory(req, res) {
@@ -11,6 +12,8 @@ export async function getCompleteInventory(req, res) {
     if (!req.session.user_id) {
       return res.status(401).json({message: "Unauthorized"})
     }
+
+    const authorId = await resolveAuthorId(req);
 
     const prismaClient = req.prisma || prisma
 
@@ -20,7 +23,7 @@ export async function getCompleteInventory(req, res) {
         book: {
           users: {
             some: {
-              id: req.session.user_id
+              id: authorId
             }
           }
         }

--- a/backend/routes/author/resolveAuthorId.js
+++ b/backend/routes/author/resolveAuthorId.js
@@ -1,0 +1,39 @@
+import { prisma } from "../../prisma/client.js";
+
+/**
+ * Resuelve de qué autor son los datos que se piden.
+ *
+ * - Un autor normal: siempre ve sus propios datos (su id de sesión).
+ * - Un admin/superadmin: puede pasar ?authorId=NN para ver los datos de ESE autor
+ *   (modo "ver como autor", de solo lectura). Si no lo pasa, ve los suyos.
+ *
+ * Devuelve el userId a usar, o null si no hay sesión válida.
+ */
+export async function resolveAuthorId(req) {
+  if (!req.session.user_id) {
+    return null;
+  }
+
+  const requestedAuthorId = req.query.authorId
+    ? parseInt(req.query.authorId)
+    : null;
+
+  // Sin override solicitado: el usuario ve sus propios datos.
+  if (!requestedAuthorId || requestedAuthorId === req.session.user_id) {
+    return req.session.user_id;
+  }
+
+  // Hay override: solo se permite si el solicitante es admin o superadmin.
+  const prismaClient = req.prisma || prisma;
+  const requester = await prismaClient.user.findUnique({
+    where: { id: req.session.user_id },
+    select: { role: true },
+  });
+
+  if (requester && (requester.role === "admin" || requester.role === "superadmin")) {
+    return requestedAuthorId;
+  }
+
+  // Un autor intentando ver los datos de otro autor: se ignora el override.
+  return req.session.user_id;
+}

--- a/backend/routes/author/sales/getAuthorSales.js
+++ b/backend/routes/author/sales/getAuthorSales.js
@@ -1,17 +1,19 @@
 import express from "express";
 import { prisma } from "../../../prisma/client.js";
-import { 
+import {
   localISODateTwelveMonthsAgo,
   today,
   validateInputs,
-  calculateAuthorRevenue 
+  calculateAuthorRevenue
 } from "../../../utils.js";
+import { resolveAuthorId } from "../resolveAuthorId.js";
 const router = express.Router();
 
 export async function getAuthorSales (req, res) {
   try {
     // Validate all inputs
     if (!req.session.user_id) {return res.status(401).json({message: "Unauthorized"});}
+    const authorId = await resolveAuthorId(req);
     const inputs = {
       startDateStr: req.query.startDateStr ? req.query.startDateStr : localISODateTwelveMonthsAgo(),
       endDateStr: req.query.endDateStr ? req.query.endDateStr : today()
@@ -29,7 +31,7 @@ export async function getAuthorSales (req, res) {
       where: {
         payments: {
           some: {
-            userId: req.session.user_id
+            userId: authorId
           }
         },
         isDeleted: false,
@@ -60,7 +62,7 @@ export async function getAuthorSales (req, res) {
       where: {
         payments: {
           some: {
-            userId: req.session.user_id
+            userId: authorId
           }
         },
         isDeleted: false,

--- a/frontend/src/AuthorComissions.jsx
+++ b/frontend/src/AuthorComissions.jsx
@@ -9,11 +9,14 @@ import Alert from "./Alert";
 import TableBookstores from "./TableBookstores";
 import { isForMonthNextMonth } from "../../backend/utils";
 import DemandPaymentButton from "./DemandPaymentButton";
+import useViewAsAuthor from "./customHooks/useViewAsAuthor";
+import ViewAsAuthorBanner from "./ViewAsAuthorBanner";
 
 function AuthorCommissions() {
   useCheckUser();
   const baseURL = import.meta.env.VITE_API_URL || '';
   const { user } = useContext(UserContext);
+  const { isViewingAsAuthor, authorName, appendAuthorParam } = useViewAsAuthor();
   const [dataByMonths, setDataByMonths] = useState(null);
   const [activeMonth, setActiveMonth] = useState(0);
   const [payments, setPayments] = useState(null);
@@ -76,7 +79,7 @@ function AuthorCommissions() {
       //   return
       // }
 
-      const response = await fetch(`${baseURL}/api/author/commissions/payments`, {
+      const response = await fetch(appendAuthorParam(`${baseURL}/api/author/commissions/payments`), {
         method: "GET",
         headers: {
           "Content-Type": "application/json",
@@ -112,7 +115,7 @@ function AuthorCommissions() {
 
   async function fetchSalesByPayments() {
     try {
-      const response = await fetch(`${baseURL}/api/author/commissions/monthlySalesByPayments`, {
+      const response = await fetch(appendAuthorParam(`${baseURL}/api/author/commissions/monthlySalesByPayments`), {
         method: "GET",
         headers: {
           "Content-Type":"application/json"
@@ -139,6 +142,7 @@ function AuthorCommissions() {
       <Navbar
         subNav={user && user.role}
         active={"comisiones"} />
+      {isViewingAsAuthor && <ViewAsAuthorBanner authorName={authorName} />}
       <div className="contain">
         <div className="author-comissions-left-side">
           <CommissionMonthSelector

--- a/frontend/src/AuthorInventory.jsx
+++ b/frontend/src/AuthorInventory.jsx
@@ -6,11 +6,14 @@ import ShowInventories from "./ShowInventories";
 import './AuthorInventory.scss';
 import BookSelector from "./BookSelector";
 import InventoryGraph from "./InventoryGraph"
+import useViewAsAuthor from "./customHooks/useViewAsAuthor";
+import ViewAsAuthorBanner from "./ViewAsAuthorBanner";
 
 function AuthorInventory(){
   useCheckUser();
   const baseURL = import.meta.env.VITE_API_URL || '';
   const { user } = useContext(UserContext);
+  const { isViewingAsAuthor, authorName, appendAuthorParam } = useViewAsAuthor();
   const [inventories, setInventories] = useState("")
   const [booksInventories, setBooksInventories] = useState([])
   const [selectedBookId, setSelectedBookId] = useState("");
@@ -48,7 +51,7 @@ function AuthorInventory(){
       //   return
       // }
 
-      const response = await fetch(`${baseURL}/api/author/inventories/authorInventories`, {
+      const response = await fetch(appendAuthorParam(`${baseURL}/api/author/inventories/authorInventories`), {
         method: "GET",
         headers: {
           "Content-Type": "application/json"
@@ -89,6 +92,7 @@ function AuthorInventory(){
     <div className="author-inventory"
       style={{ fontSize: `clamp(0.8rem, ${user.font_size}rem, 1.5rem)`}}>
     <Navbar subNav={user && user.role} active={"inventario"} />
+    {isViewingAsAuthor && <ViewAsAuthorBanner authorName={authorName} />}
     <div id="author-page-container">
       <div id="author-page-content">
         <div id="author-inventory-container">

--- a/frontend/src/AuthorSales.jsx
+++ b/frontend/src/AuthorSales.jsx
@@ -13,11 +13,14 @@ import {
   localISODateTwelveMonthsAgo
 } from '../../backend/utils';
 import Alert from "./Alert";
+import useViewAsAuthor from "./customHooks/useViewAsAuthor";
+import ViewAsAuthorBanner from "./ViewAsAuthorBanner";
 
 function AuthorSales() {
   useCheckUser();
   const baseURL = import.meta.env.VITE_API_URL || '';
   const { user } = useContext(UserContext);
+  const { isViewingAsAuthor, authorName, appendAuthorParam } = useViewAsAuthor();
   const [salesData, setSalesData] = useState(null);
   const [monthlyData, setMonthlyData] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -128,7 +131,7 @@ function processMonthlyData(sales, bookId = 'total') {
         endDateStr: dateRange.endDateStr
       });
 
-      const response = await fetch(`${baseURL}/api/author/sales/sales?${queryParams}`, {
+      const response = await fetch(appendAuthorParam(`${baseURL}/api/author/sales/sales?${queryParams}`), {
         credentials: 'include',
         headers: {
           'Content-Type': 'application/json'
@@ -211,6 +214,7 @@ function processMonthlyData(sales, bookId = 'total') {
     <div className="author-sales"
       style={{ fontSize: `clamp(0.8rem, ${user.font_size}rem, 1.5rem)`}}>
       <Navbar subNav={user.role} active={"ventas"} />
+      {isViewingAsAuthor && <ViewAsAuthorBanner authorName={authorName} />}
       <div id="author-sales-container">
         <div className="date-range-selector">
           <div className="date-input">

--- a/frontend/src/PaymentsList.jsx
+++ b/frontend/src/PaymentsList.jsx
@@ -1,6 +1,9 @@
 import useCheckAdmin from "./customHooks/useCheckAdmin";
 import { useEffect, useState, useMemo, useContext } from "react";
+import { useNavigate } from "react-router-dom";
 import { MaterialReactTable, useMaterialReactTable } from 'material-react-table';
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEye } from "@fortawesome/free-solid-svg-icons";
 import UserContext from "./UserContext";
 import Navbar from "./Navbar";
 import Alert from "./Alert";
@@ -13,7 +16,17 @@ import formatNumber from "./customHooks/formatNumber";
 function PaymentsList() {
   useCheckAdmin();
   const baseURL = import.meta.env.VITE_API_URL || '';
+  const navigate = useNavigate();
   const { user } = useContext(UserContext);
+
+  // Abre las pantallas del autor (modo "ver como autor") para verificar su desglose.
+  function viewAsAuthor(row) {
+    const authorId = row.original.userId;
+    const authorName = encodeURIComponent(
+      `${row.original.user?.first_name ?? ""} ${row.original.user?.last_name ?? ""}`.trim()
+    );
+    navigate(`/author/commissions?authorId=${authorId}&authorName=${authorName}`);
+  }
   const [data, setData] = useState([]);
   const [total, setTotal] = useState(0);
   const [chosenPaymentStatus, setChosenPaymentStatus] = useState("solicited");
@@ -51,6 +64,17 @@ function PaymentsList() {
           overflow: "visible"
         }
       }
+    },
+    {
+      header: "Desglose",
+      Cell: ({row}) => (
+        <button
+          className="view-as-author-btn"
+          title="Ver el desglose como lo ve el autor"
+          onClick={() => viewAsAuthor(row)}>
+          <FontAwesomeIcon icon={faEye} /> Ver desglose
+        </button>
+      )
     },
     {
       header: "Monto",

--- a/frontend/src/PaymentsList.scss
+++ b/frontend/src/PaymentsList.scss
@@ -16,3 +16,23 @@
 .payment-type-label {
     margin-bottom: 0.5rem;
 }
+// Botón "Ver desglose" (modo ver como autor)
+.view-as-author-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: #4E6CB3;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.4rem 0.7rem;
+  font-family: "Roboto", sans-serif;
+  font-size: 0.82rem;
+  font-weight: 700;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background 0.15s, transform 0.1s;
+
+  &:hover { background: #3f5a99; }
+  &:active { transform: translateY(1px); }
+}

--- a/frontend/src/ViewAsAuthorBanner.jsx
+++ b/frontend/src/ViewAsAuthorBanner.jsx
@@ -1,0 +1,31 @@
+import { useNavigate } from "react-router-dom";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faArrowLeft, faEye } from "@fortawesome/free-solid-svg-icons";
+import "./ViewAsAuthorBanner.scss";
+
+/**
+ * Banner que se muestra cuando un admin está viendo las pantallas de un autor.
+ * Indica de quién son los datos y ofrece volver a la pantalla de Pagos.
+ */
+function ViewAsAuthorBanner({ authorName }) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="vaa-banner">
+      <div className="vaa-banner-info">
+        <FontAwesomeIcon icon={faEye} />
+        <span>
+          Viendo como autor:&nbsp;
+          <strong>{authorName || "autor seleccionado"}</strong>
+          &nbsp;(solo lectura)
+        </span>
+      </div>
+      <button className="vaa-banner-back" onClick={() => navigate("/admin/payments")}>
+        <FontAwesomeIcon icon={faArrowLeft} />
+        Volver a Pagos
+      </button>
+    </div>
+  );
+}
+
+export default ViewAsAuthorBanner;

--- a/frontend/src/ViewAsAuthorBanner.scss
+++ b/frontend/src/ViewAsAuthorBanner.scss
@@ -1,0 +1,46 @@
+.vaa-banner {
+  position: fixed;
+  top: 50px;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  background: #4E6CB3;
+  color: #fff;
+  padding: 0.5rem 1.25rem;
+  font-family: "Roboto", sans-serif;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+}
+
+.vaa-banner-info {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-size: 0.95rem;
+
+  svg { opacity: 0.9; }
+  strong { font-weight: 700; }
+}
+
+.vaa-banner-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  background: #fff;
+  color: #4E5981;
+  border: none;
+  border-radius: 8px;
+  padding: 0.4rem 0.9rem;
+  font-family: "Roboto", sans-serif;
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s, transform 0.1s;
+
+  &:hover { background: #eef0f6; }
+  &:active { transform: translateY(1px); }
+}

--- a/frontend/src/customHooks/useViewAsAuthor.jsx
+++ b/frontend/src/customHooks/useViewAsAuthor.jsx
@@ -1,0 +1,32 @@
+import { useSearchParams } from "react-router-dom";
+
+/**
+ * Soporta el modo "ver como autor" para administradores.
+ *
+ * Cuando un admin entra a una pantalla de autor con ?authorId=NN&authorName=...
+ * en la URL, este hook expone ese id para añadirlo a las llamadas al backend,
+ * y los datos para mostrar un banner de "estás viendo como <autor>".
+ *
+ * Para un autor normal (sin esos parámetros) todo queda vacío y las pantallas
+ * funcionan exactamente igual que antes.
+ */
+function useViewAsAuthor() {
+  const [searchParams] = useSearchParams();
+  const authorId = searchParams.get("authorId");
+  const authorName = searchParams.get("authorName");
+
+  const isViewingAsAuthor = Boolean(authorId);
+
+  // Sufijo listo para concatenar a un endpoint.
+  // - appendAuthorParam("...?foo=bar")  -> "...?foo=bar&authorId=NN"
+  // - appendAuthorParam("...")          -> "...?authorId=NN"
+  function appendAuthorParam(url) {
+    if (!authorId) return url;
+    const separator = url.includes("?") ? "&" : "?";
+    return `${url}${separator}authorId=${authorId}`;
+  }
+
+  return { authorId, authorName, isViewingAsAuthor, appendAuthorParam };
+}
+
+export default useViewAsAuthor;


### PR DESCRIPTION
Permite a un admin abrir las 3 pantallas del autor (Comisiones, Ventas, Inventario) con los datos de un autor específico, para verificar su desglose desde la pantalla de Pagos.

Backend:
- Nuevo helper resolveAuthorId: un admin puede pasar ?authorId=NN para ver los datos de ese autor; un autor normal solo ve los suyos (seguro).
- Aplicado a los 6 endpoints de /api/author (comisiones, ventas, inventario).

Frontend:
- Hook useViewAsAuthor + banner ViewAsAuthorBanner (solo lectura + volver).
- Las 3 pantallas de autor propagan authorId a sus fetches.
- Botón 'Ver desglose' en cada fila de PaymentsList.