### PR TITLE
fix(inventarios): recordar el libro abierto al volver de otra pestaña

### DIFF
--- a/frontend/src/InventoriesList.jsx
+++ b/frontend/src/InventoriesList.jsx
@@ -208,6 +208,7 @@ function InventoriesList() {
           const data = await response.json();
           setSpecificBookstore(data);
           setSpecificBookstoreOpen(true);
+          sessionStorage.setItem("lastOpenedInventory", JSON.stringify({ type: "bookstore", id }));
         }
       } else if (type === "book") {
         const response = await fetch(`${baseURL}/api/admin/inventories/inventoriesByBook/${id}`, {
@@ -222,6 +223,8 @@ function InventoriesList() {
           const data = await response.json();
           setSpecificBook(data);
           setSpecificBookOpen(true);
+          // Recordar el libro abierto para volver a él al regresar de otra pestaña
+          sessionStorage.setItem("lastOpenedInventory", JSON.stringify({ type: "book", id }));
         }
       }
 
@@ -251,6 +254,31 @@ function InventoriesList() {
 
   useEffect(() => {
     getBookstoreInventories();
+  }, []);
+
+  // Al volver a esta pantalla, reabrir el último inventario que estaba abierto
+  // (para no tener que volver a buscar el libro tras pasar por otra pestaña).
+  useEffect(() => {
+    const saved = sessionStorage.getItem("lastOpenedInventory");
+    if (!saved) return;
+    try {
+      const { type, id } = JSON.parse(saved);
+      if (type === "book") {
+        // activar la vista "por libro" (ajusta columnas) y reabrir el libro
+        setInventoryType(true);
+        setColumnVisibility({
+          "name": true, "initial": true, "extraImpressions": true,
+          "copias": false, "returns": false, "entregadosAlAutor": true,
+          "transfers": false, "ventas": true,
+        });
+        getBookInventories();
+        openSpecifics("book", id);
+      } else if (type === "bookstore") {
+        openSpecifics("bookstore", id);
+      }
+    } catch (e) {
+      console.error("No se pudo restaurar el inventario abierto:", e);
+    }
   }, []);
 
   async function getBookInventories() {

--- a/frontend/src/InventoryTotal.jsx
+++ b/frontend/src/InventoryTotal.jsx
@@ -64,6 +64,9 @@ function InventoryTotal({
   }, [selectedBookstore, selectedBook, impressions])
 
   function returnToInventoriesAreaDashboard() {
+    // El usuario cierra el detalle a propósito: olvidar el inventario recordado
+    // para no reabrirlo automáticamente la próxima vez.
+    sessionStorage.removeItem("lastOpenedInventory");
     if (type === "book") {
       setSpecificBookOpen(false);
     } else {


### PR DESCRIPTION
Antes, al abrir el inventario de un libro, ir a otra pestaña (ej. Ventas) y volver a Inventarios, se perdía el libro y había que buscarlo de nuevo.

Ahora el libro/librería abierto se guarda en sessionStorage y se restaura automáticamente al volver a la pantalla de Inventarios. Al cerrar el detalle a propósito (botón volver), se olvida para mostrar la lista normal.