### PR TITLE
feat(pagos): arrastrar saldo negativo entre meses

### DIFF
--- a/backend/routes/admin/payments/carryOverBalance.js
+++ b/backend/routes/admin/payments/carryOverBalance.js
@@ -1,0 +1,77 @@
+/**
+ * Arrastre de saldo negativo entre meses (cuenta corriente del autor).
+ *
+ * Regla de negocio:
+ * - Cada mes tiene un balance crudo (ventas + kindle - costos).
+ * - Se lleva un acumulado en orden cronológico.
+ * - Si el acumulado es negativo: el mes "muestra" ese negativo, pero el pago
+ *   efectivo es 0, y el negativo se arrastra al mes siguiente.
+ * - Si el acumulado es positivo: ese acumulado es lo que se paga.
+ * - Un mes ya PAGADO (status "paid") cierra/resetea el acumulado a 0
+ *   (ese dinero ya salió; no se recalcula).
+ *
+ * IMPORTANTE: el redondeo se hace en centavos para evitar errores de coma
+ * flotante (consistente con utils.js — es dinero real de autores).
+ *
+ * @param {Array<{forMonth: string, status?: string, amount: number}>} months
+ *   Meses con su balance crudo (amount). NO necesita venir ordenado.
+ * @returns {Array} los mismos meses, en el MISMO orden de entrada, con:
+ *   - rawAmount: el balance del mes por sí solo (lo que antes era "amount")
+ *   - carriedIn: saldo que venía arrastrado del mes anterior
+ *   - displayAmount: saldo acumulado a mostrar (puede ser negativo)
+ *   - payableAmount: lo que efectivamente se paga ese mes (0 si negativo)
+ */
+export function applyCarryOver(months) {
+  // Ordenar cronológicamente por forMonth ("YYYY-MM" se ordena como string)
+  const chronological = [...months].sort((a, b) =>
+    a.forMonth.localeCompare(b.forMonth)
+  );
+
+  let carryCents = 0; // acumulado arrastrado, en centavos
+
+  const byMonth = new Map();
+  for (const m of chronological) {
+    const rawCents = Math.round((m.amount ?? 0) * 100);
+
+    if (m.status === "paid") {
+      // El mes ya se pagó: ese dinero ya salió. El acumulado se cierra.
+      byMonth.set(m.forMonth, {
+        ...m,
+        rawAmount: rawCents / 100,
+        carriedIn: 0,
+        displayAmount: rawCents / 100,
+        payableAmount: rawCents / 100,
+      });
+      carryCents = 0;
+      continue;
+    }
+
+    const carriedInCents = carryCents;
+    const accumulatedCents = carriedInCents + rawCents;
+
+    if (accumulatedCents < 0) {
+      // Sigue en negativo: se muestra el negativo, se paga 0, se arrastra.
+      byMonth.set(m.forMonth, {
+        ...m,
+        rawAmount: rawCents / 100,
+        carriedIn: carriedInCents / 100,
+        displayAmount: accumulatedCents / 100,
+        payableAmount: 0,
+      });
+      carryCents = accumulatedCents;
+    } else {
+      // Acumulado positivo (o cero): se paga el acumulado, se resetea.
+      byMonth.set(m.forMonth, {
+        ...m,
+        rawAmount: rawCents / 100,
+        carriedIn: carriedInCents / 100,
+        displayAmount: accumulatedCents / 100,
+        payableAmount: accumulatedCents / 100,
+      });
+      carryCents = 0;
+    }
+  }
+
+  // Devolver en el orden original de entrada
+  return months.map((m) => byMonth.get(m.forMonth));
+}

--- a/backend/routes/admin/payments/getPayments.js
+++ b/backend/routes/admin/payments/getPayments.js
@@ -1,9 +1,10 @@
 import express from "express";
 import { prisma } from "../../../prisma/client.js";
-import { 
+import {
   validateInputs,
-  calculateAuthorRevenue 
+  calculateAuthorRevenue
 } from "../../../utils.js";
+import { applyCarryOver } from "./carryOverBalance.js";
 const router = express.Router();
 
 export async function getPayments(req, res) {
@@ -15,10 +16,12 @@ export async function getPayments(req, res) {
 
     const prismaClient = req.prisma || prisma
 
+    // Traemos TODOS los pagos no borrados (no solo el estado pedido) porque el
+    // arrastre de saldo negativo necesita ver el historial completo de cada
+    // autor en orden cronológico para acumular correctamente.
     const selectedPayments = await prismaClient.payment.findMany({
       where: {
-        isDeleted: false,
-        status: inputs.status
+        isDeleted: false
       },
       select: {
         id: true,
@@ -140,19 +143,39 @@ export async function getPayments(req, res) {
       ])
     }
 
-    const paymentsSent = [];
-    const promises = selectedPayments.map(payment => updateAmount(payment));
-    for (const payment of selectedPayments) {
-      if (payment.amount) {
-        paymentsSent.push(payment)
-      }
-    }
-    const results = await Promise.all(promises)
+    // 1) Calcular el balance crudo de cada mes
+    await Promise.all(selectedPayments.map(payment => updateAmount(payment)));
 
-    // get a total
-    let totalAmount = 0;
+    // 2) Agrupar por autor y aplicar el arrastre de saldo negativo por autor
+    const byUser = new Map();
     for (const payment of selectedPayments) {
-      totalAmount += payment.amount
+      if (!byUser.has(payment.userId)) byUser.set(payment.userId, []);
+      byUser.get(payment.userId).push(payment);
+    }
+    for (const [, userPayments] of byUser) {
+      const withCarry = applyCarryOver(userPayments);
+      // applyCarryOver preserva el orden, así que mapeamos por índice
+      withCarry.forEach((m, i) => {
+        userPayments[i].rawAmount = m.rawAmount;
+        userPayments[i].displayAmount = m.displayAmount;   // saldo acumulado (puede ser negativo)
+        userPayments[i].payableAmount = m.payableAmount;   // lo que se paga (0 si negativo)
+        // 'amount' = lo que efectivamente se paga, para no romper el frontend existente
+        userPayments[i].amount = m.payableAmount;
+      });
+    }
+
+    // 3) Devolver solo los pagos del estado pedido.
+    //    Mostramos los que tienen un monto a pagar (payableAmount > 0) o un
+    //    saldo arrastrado distinto de 0 (para que el negativo sea visible).
+    const paymentsSent = selectedPayments.filter(
+      (p) => p.status === inputs.status &&
+             (p.payableAmount > 0 || p.displayAmount !== 0)
+    );
+
+    // total = suma de lo efectivamente pagable de los mostrados
+    let totalAmount = 0;
+    for (const payment of paymentsSent) {
+      totalAmount += payment.payableAmount;
     }
 
     const finalPayload = {

--- a/backend/routes/author/commissions/getAuthorPayments.js
+++ b/backend/routes/author/commissions/getAuthorPayments.js
@@ -5,6 +5,7 @@ import {
   generateMonthKeysForRange,
 } from "../../../utils.js"
 import { resolveAuthorId } from "../resolveAuthorId.js";
+import { applyCarryOver } from "../../admin/payments/carryOverBalance.js";
 const router = express.Router();
 
 export async function getAuthorPayments (req, res) {
@@ -153,7 +154,16 @@ export async function getAuthorPayments (req, res) {
       }
     }
 
-    res.status(200).json(paymentsPerMonth);
+    // Aplicar el arrastre de saldo negativo: un mes en negativo se muestra en
+    // negativo (displayAmount) y se acumula hasta volverse positivo.
+    const withCarry = applyCarryOver(paymentsPerMonth);
+    const finalPayments = withCarry.map((m) => ({
+      ...m,
+      amount: m.displayAmount,        // lo que se muestra al autor (acumulado)
+      payableAmount: m.payableAmount, // lo que efectivamente se le pagaría
+    }));
+
+    res.status(200).json(finalPayments);
   } catch (error) {
     console.log("\n ERROR WHILE FETCHING PAYMENTS FROM SERVER \n", error);
     res.status(500).json({error: "a server error occurred"})

--- a/backend/routes/author/commissions/getMonthlySalesByPayment.js
+++ b/backend/routes/author/commissions/getMonthlySalesByPayment.js
@@ -6,6 +6,7 @@ import {
   generateMonthKeysForRange,
 } from "../../../utils.js"
 import { resolveAuthorId } from "../resolveAuthorId.js";
+import { applyCarryOver } from "../../admin/payments/carryOverBalance.js";
 const router = express.Router();
 
 export async function getMonthlySalesByPayments (req, res) {
@@ -344,6 +345,27 @@ export async function getMonthlySalesByPayments (req, res) {
             "costs": []
           })
         }
+      }
+    } else {
+      paddedMonthlySales = monthlySales
+    }
+
+    // Aplicar el arrastre de saldo negativo sobre el total de cada mes.
+    // displayValue = saldo acumulado a mostrar (puede ser negativo).
+    const carry = applyCarryOver(
+      paddedMonthlySales.map((m) => ({
+        forMonth: m.forMonth,
+        amount: m.totalValue ?? 0,
+      }))
+    );
+    const carryByMonth = Object.fromEntries(carry.map((m) => [m.forMonth, m]));
+    for (const month of paddedMonthlySales) {
+      const c = carryByMonth[month.forMonth];
+      if (c) {
+        month.monthValue = month.totalValue ?? 0;  // valor solo de ese mes
+        month.totalValue = c.displayAmount;         // valor acumulado con arrastre
+        month.payableAmount = c.payableAmount;      // lo que se pagaría
+        month.carriedIn = c.carriedIn;              // saldo que venía arrastrado
       }
     }
 

--- a/backend/tests/admin/carryOverBalance.test.js
+++ b/backend/tests/admin/carryOverBalance.test.js
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { applyCarryOver } from "../../routes/admin/payments/carryOverBalance.js";
+
+describe("applyCarryOver — arrastre de saldo negativo", () => {
+  it("arrastra un negativo y lo convierte en positivo al acumularse", () => {
+    const input = [
+      { forMonth: "2026-01", amount: -500 },
+      { forMonth: "2026-02", amount: 300 },
+      { forMonth: "2026-03", amount: 700 },
+    ];
+    const res = applyCarryOver(input);
+    const byMonth = Object.fromEntries(res.map((m) => [m.forMonth, m]));
+
+    // Mes 1: -500 -> muestra -500, paga 0
+    expect(byMonth["2026-01"].displayAmount).toBe(-500);
+    expect(byMonth["2026-01"].payableAmount).toBe(0);
+
+    // Mes 2: -500 + 300 = -200 -> muestra -200, paga 0
+    expect(byMonth["2026-02"].displayAmount).toBe(-200);
+    expect(byMonth["2026-02"].payableAmount).toBe(0);
+
+    // Mes 3: -200 + 700 = +500 -> muestra 500, paga 500
+    expect(byMonth["2026-03"].displayAmount).toBe(500);
+    expect(byMonth["2026-03"].payableAmount).toBe(500);
+  });
+
+  it("un mes positivo normal se paga completo sin arrastre previo", () => {
+    const res = applyCarryOver([{ forMonth: "2026-05", amount: 1000 }]);
+    expect(res[0].displayAmount).toBe(1000);
+    expect(res[0].payableAmount).toBe(1000);
+  });
+
+  it("un mes ya pagado resetea el acumulado", () => {
+    const input = [
+      { forMonth: "2026-01", amount: -400 },     // arrastra -400
+      { forMonth: "2026-02", amount: 1000, status: "paid" }, // pagado: resetea
+      { forMonth: "2026-03", amount: -100 },     // empieza de cero -> -100
+    ];
+    const res = applyCarryOver(input);
+    const byMonth = Object.fromEntries(res.map((m) => [m.forMonth, m]));
+
+    expect(byMonth["2026-02"].payableAmount).toBe(1000); // pagado intacto
+    // El -400 NO se arrastra más allá del mes pagado
+    expect(byMonth["2026-03"].displayAmount).toBe(-100);
+    expect(byMonth["2026-03"].payableAmount).toBe(0);
+  });
+
+  it("preserva el orden de entrada", () => {
+    const input = [
+      { forMonth: "2026-03", amount: 700 },
+      { forMonth: "2026-01", amount: -500 },
+      { forMonth: "2026-02", amount: 300 },
+    ];
+    const res = applyCarryOver(input);
+    expect(res.map((m) => m.forMonth)).toEqual(["2026-03", "2026-01", "2026-02"]);
+  });
+
+  it("maneja centavos sin errores de coma flotante", () => {
+    const input = [
+      { forMonth: "2026-01", amount: -0.1 },
+      { forMonth: "2026-02", amount: -0.2 },
+    ];
+    const res = applyCarryOver(input);
+    const byMonth = Object.fromEntries(res.map((m) => [m.forMonth, m]));
+    expect(byMonth["2026-02"].displayAmount).toBe(-0.3); // no -0.30000000000000004
+  });
+});

--- a/frontend/src/customHooks/formatNumber.jsx
+++ b/frontend/src/customHooks/formatNumber.jsx
@@ -5,7 +5,9 @@ function formatNumber(total) {
     return;
   }
 
-  const strTotal = total.toString();
+  // Separar el signo para no descuadrar los grupos de miles en negativos
+  const sign = total < 0 ? "-" : "";
+  const strTotal = Math.abs(total).toString();
   const splitTotal = strTotal.split(".");
   let firstPart = '';
   for (let i = 0; i < splitTotal[0].length; i++) {
@@ -17,14 +19,14 @@ function formatNumber(total) {
   }
 
   if (splitTotal.length < 2) {
-    return "$ " + firstPart + ".00";
+    return "$ " + sign + firstPart + ".00";
   };
 
   let secondPart = splitTotal[1].substring(0,2);
   if (secondPart.length === 1) {
     secondPart += "0"
   }
-  return "$ " + firstPart + "." + secondPart;
+  return "$ " + sign + firstPart + "." + secondPart;
 }
 
 export default formatNumber;


### PR DESCRIPTION
Antes, un mes con balance negativo se trataba aislado. Ahora el saldo negativo se arrastra a los meses siguientes (cuenta corriente del autor) hasta que las ventas lo compensan y vuelve a positivo.

- Nuevo helper applyCarryOver (centavos enteros) + tests (5 casos).
- Regla: mes negativo muestra el acumulado pero paga 0; un mes ya pagado resetea el acumulado; aplica solo de aquí en adelante.
- Integrado en los 3 cálculos de monto por mes: getPayments (admin), getAuthorPayments y getMonthlySalesByPayment (autor).
- Fix de formatNumber: el signo negativo descuadraba los miles ($ -,900 -> $ -900).